### PR TITLE
feat: Add revert command to restore config from backup

### DIFF
--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -95,7 +95,7 @@ def revert() -> None:
     try:
         current_config = desktop_config.load_config(cfg_path)
         before = current_config if cfg_path.exists() else None
-    except desktop_config.ConfigError:
+    except (desktop_config.ConfigError, OSError):
         before = None
 
     diff_text = output.format_diff(

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -77,3 +77,33 @@ def add(
         desktop_config.write_config(cfg_path, merged)
         msg = output.write_message(name, name_was_derived, cfg_path, file_existed)
         typer.echo(msg)
+
+
+@app.command()
+def revert() -> None:
+    cfg_path = desktop_config.config_path()
+
+    try:
+        backup_config = desktop_config.load_backup(cfg_path)
+    except desktop_config.BackupNotFoundError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(code=1)
+    except desktop_config.BackupError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        current_config = desktop_config.load_config(cfg_path)
+    except desktop_config.ConfigError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(code=1)
+
+    file_existed = cfg_path.exists()
+    before = None if not file_existed else current_config
+
+    diff_text = output.format_diff(
+        before, backup_config, from_label="before", to_label="after"
+    )
+    desktop_config.revert_config(cfg_path, backup_config)
+    msg = output.revert_message(cfg_path, diff_text)
+    typer.echo(msg)

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -94,12 +94,9 @@ def revert() -> None:
 
     try:
         current_config = desktop_config.load_config(cfg_path)
-    except desktop_config.ConfigError as e:
-        typer.echo(str(e), err=True)
-        raise typer.Exit(code=1)
-
-    file_existed = cfg_path.exists()
-    before = None if not file_existed else current_config
+        before = current_config if cfg_path.exists() else None
+    except desktop_config.ConfigError:
+        before = None
 
     diff_text = output.format_diff(
         before, backup_config, from_label="before", to_label="after"

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -17,6 +17,14 @@ class EntryExistsError(Exception):
     pass
 
 
+class BackupNotFoundError(Exception):
+    pass
+
+
+class BackupError(Exception):
+    pass
+
+
 def config_path() -> Path:
     env = os.environ.get("CLAUDE_DESKTOP_CONFIG")
     if env:
@@ -33,6 +41,10 @@ def config_path() -> Path:
     )
 
 
+def backup_path(path: Path) -> Path:
+    return path.with_suffix(path.suffix + ".bak")
+
+
 def load_config(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {"mcpServers": {}}
@@ -42,6 +54,19 @@ def load_config(path: Path) -> dict[str, Any]:
     except (json.JSONDecodeError, ValueError) as e:
         raise ConfigError(
             f"Failed to parse JSON config file: {path}\nPlease check the file: {e}"
+        ) from e
+
+
+def load_backup(path: Path) -> dict[str, Any]:
+    bak = backup_path(path)
+    if not bak.exists():
+        raise BackupNotFoundError(f"Backup not found: {bak}")
+    try:
+        text = bak.read_text(encoding="utf-8")
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError) as e:
+        raise BackupError(
+            f"Backup file is corrupted: {bak}\nPlease check the file: {e}"
         ) from e
 
 
@@ -73,14 +98,8 @@ def serialize_config(config: dict[str, Any]) -> str:
     return json.dumps(config, indent=2, ensure_ascii=False) + "\n"
 
 
-def write_config(path: Path, config: dict[str, Any]) -> None:
+def _atomic_write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-
-    if path.exists():
-        backup = path.with_suffix(path.suffix + ".bak")
-        shutil.copy2(path, backup)
-
-    content = serialize_config(config)
     dir_ = path.parent
     fd, tmp = tempfile.mkstemp(dir=dir_, suffix=".tmp")
     fd_closed = False
@@ -95,3 +114,14 @@ def write_config(path: Path, config: dict[str, Any]) -> None:
         if os.path.exists(tmp):
             os.unlink(tmp)
         raise
+
+
+def write_config(path: Path, config: dict[str, Any]) -> None:
+    if path.exists():
+        shutil.copy2(path, backup_path(path))
+    _atomic_write(path, serialize_config(config))
+
+
+def revert_config(path: Path, config: dict[str, Any]) -> None:
+    _atomic_write(path, serialize_config(config))
+    backup_path(path).unlink()

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -68,6 +68,10 @@ def load_backup(path: Path) -> dict[str, Any]:
         raise BackupError(
             f"Backup file is corrupted: {bak}\nPlease check the file: {e}"
         ) from e
+    except OSError as e:
+        raise BackupError(
+            f"Cannot read backup file: {bak}\nPlease check the file: {e}"
+        ) from e
 
 
 def build_entry(mcp_proxy_path: Path, transport: str, url: str) -> dict[str, Any]:

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -10,10 +10,13 @@ from . import desktop_config
 def format_diff(
     current_config: dict[str, Any] | None,
     proposed_config: dict[str, Any],
+    *,
+    from_label: str = "current",
+    to_label: str = "proposed",
 ) -> str:
     if current_config is None:
         current_lines: list[str] = []
-        header = "--- (file does not exist; will be created)\n+++ proposed\n"
+        header = f"--- (file does not exist; will be created)\n+++ {to_label}\n"
     else:
         current_text = desktop_config.serialize_config(current_config)
         current_lines = current_text.splitlines(keepends=True)
@@ -25,8 +28,8 @@ def format_diff(
     diff = difflib.unified_diff(
         current_lines,
         proposed_lines,
-        fromfile="current",
-        tofile="proposed",
+        fromfile=from_label,
+        tofile=to_label,
     )
     if header:
         diff_lines = list(diff)
@@ -55,6 +58,22 @@ def preview_message(
     lines.append("")
     lines.append("This is a preview. Re-run with --write to apply.")
     lines.append("To use a different name: --name <your-name>")
+    return "\n".join(lines)
+
+
+def revert_message(
+    config_path: Path,
+    diff_text: str,
+) -> str:
+    lines: list[str] = []
+    lines.append(f"Reverted: {config_path}")
+    backup = config_path.with_suffix(config_path.suffix + ".bak")
+    lines.append(f"Removed:  {backup}")
+    if diff_text.strip():
+        lines.append("")
+        lines.append(diff_text.rstrip())
+    lines.append("")
+    lines.append("Reverted to backup. Restart Claude Desktop to take effect.")
     return "\n".join(lines)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -152,6 +152,17 @@ class TestRevert:
         assert result.exit_code == 1
         assert "corrupted" in result.output
 
+    def test_revert_with_corrupted_config(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text("not json")
+        bak = config_file.with_suffix(".json.bak")
+        bak.write_text(json.dumps({"mcpServers": {}}))
+        result = runner.invoke(app, ["revert"])
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        assert data == {"mcpServers": {}}
+        assert not bak.exists()
+
     def test_revert_removes_backup_file(self, config_env):
         config_file, _ = config_env
         original = {"mcpServers": {"old": {"command": "x"}}}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,3 +114,51 @@ class TestAddErrors:
         result = runner.invoke(app, ["add", "https://localhost/mcp"])
         assert result.exit_code == 1
         assert "--name" in result.output
+
+
+class TestRevert:
+    def test_revert_after_add(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text(json.dumps({"mcpServers": {}}))
+        runner.invoke(app, ["add", "https://mcp.notion.com/mcp", "--write"])
+        result = runner.invoke(app, ["revert"])
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        assert "notion" not in data["mcpServers"]
+        assert not config_file.with_suffix(".json.bak").exists()
+        assert "Reverted" in result.output
+        assert "Restart Claude Desktop" in result.output
+
+    def test_revert_shows_diff(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text(json.dumps({"mcpServers": {}}))
+        runner.invoke(app, ["add", "https://mcp.notion.com/mcp", "--write"])
+        result = runner.invoke(app, ["revert"])
+        assert result.exit_code == 0
+        assert "--- before" in result.output
+        assert "+++ after" in result.output
+
+    def test_revert_no_backup(self, config_env):
+        config_file, _ = config_env
+        result = runner.invoke(app, ["revert"])
+        assert result.exit_code == 1
+        assert "Backup not found" in result.output
+
+    def test_revert_corrupted_backup(self, config_env):
+        config_file, _ = config_env
+        bak = config_file.with_suffix(".json.bak")
+        bak.write_text("not json")
+        result = runner.invoke(app, ["revert"])
+        assert result.exit_code == 1
+        assert "corrupted" in result.output
+
+    def test_revert_removes_backup_file(self, config_env):
+        config_file, _ = config_env
+        original = {"mcpServers": {"old": {"command": "x"}}}
+        config_file.write_text(json.dumps({"mcpServers": {"old": {"command": "x"}, "notion": {}}}))
+        bak = config_file.with_suffix(".json.bak")
+        bak.write_text(json.dumps(original))
+        result = runner.invoke(app, ["revert"])
+        assert result.exit_code == 0
+        assert not bak.exists()
+        assert "Removed:" in result.output

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -4,12 +4,17 @@ from pathlib import Path
 import pytest
 
 from cdcasasagi.desktop_config import (
+    BackupError,
+    BackupNotFoundError,
     ConfigError,
     EntryExistsError,
+    backup_path,
     build_entry,
     config_path,
+    load_backup,
     load_config,
     merge_entry,
+    revert_config,
     write_config,
 )
 
@@ -37,6 +42,15 @@ class TestConfigPath:
         monkeypatch.setenv("APPDATA", "/fake/appdata")
         result = config_path()
         assert result == Path("/fake/appdata/Claude/claude_desktop_config.json")
+
+
+class TestBackupPath:
+    def test_basic(self):
+        assert backup_path(Path("/tmp/config.json")) == Path("/tmp/config.json.bak")
+
+    def test_preserves_directory(self):
+        p = Path("/home/user/.config/claude_desktop_config.json")
+        assert backup_path(p).parent == p.parent
 
 
 class TestLoadConfig:
@@ -134,4 +148,57 @@ class TestWriteConfig:
     def test_trailing_newline(self, tmp_path):
         p = tmp_path / "config.json"
         write_config(p, {"mcpServers": {}})
+        assert p.read_text().endswith("\n")
+
+
+class TestLoadBackup:
+    def test_backup_not_found(self, tmp_path):
+        p = tmp_path / "config.json"
+        with pytest.raises(BackupNotFoundError):
+            load_backup(p)
+
+    def test_valid_backup(self, tmp_path):
+        p = tmp_path / "config.json"
+        bak = tmp_path / "config.json.bak"
+        bak.write_text('{"mcpServers": {}}')
+        assert load_backup(p) == {"mcpServers": {}}
+
+    def test_corrupted_backup(self, tmp_path):
+        p = tmp_path / "config.json"
+        bak = tmp_path / "config.json.bak"
+        bak.write_text("not json")
+        with pytest.raises(BackupError):
+            load_backup(p)
+
+
+class TestRevertConfig:
+    def test_reverts_content(self, tmp_path):
+        p = tmp_path / "config.json"
+        p.write_text(json.dumps({"mcpServers": {"new": {}}}))
+        bak = tmp_path / "config.json.bak"
+        bak.write_text(json.dumps({"mcpServers": {}}))
+        revert_config(p, {"mcpServers": {}})
+        assert json.loads(p.read_text()) == {"mcpServers": {}}
+
+    def test_deletes_backup(self, tmp_path):
+        p = tmp_path / "config.json"
+        p.write_text(json.dumps({"mcpServers": {"new": {}}}))
+        bak = tmp_path / "config.json.bak"
+        bak.write_text(json.dumps({"mcpServers": {}}))
+        revert_config(p, {"mcpServers": {}})
+        assert not bak.exists()
+
+    def test_creates_file_if_not_exists(self, tmp_path):
+        p = tmp_path / "config.json"
+        bak = tmp_path / "config.json.bak"
+        bak.write_text(json.dumps({"mcpServers": {}}))
+        revert_config(p, {"mcpServers": {}})
+        assert p.exists()
+        assert not bak.exists()
+
+    def test_trailing_newline(self, tmp_path):
+        p = tmp_path / "config.json"
+        bak = tmp_path / "config.json.bak"
+        bak.write_text(json.dumps({"mcpServers": {}}))
+        revert_config(p, {"mcpServers": {}})
         assert p.read_text().endswith("\n")

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -170,6 +170,13 @@ class TestLoadBackup:
         with pytest.raises(BackupError):
             load_backup(p)
 
+    def test_unreadable_backup(self, tmp_path):
+        p = tmp_path / "config.json"
+        bak = tmp_path / "config.json.bak"
+        bak.mkdir()  # directory, not a file
+        with pytest.raises(BackupError, match="Cannot read"):
+            load_backup(p)
+
 
 class TestRevertConfig:
     def test_reverts_content(self, tmp_path):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from cdcasasagi.output import format_diff, preview_message, write_message
+from cdcasasagi.output import format_diff, preview_message, revert_message, write_message
 
 
 def test_format_diff_new_file():
@@ -44,3 +44,35 @@ def test_write_message_no_backup():
     msg = write_message("notion", True, Path("/tmp/config.json"), file_existed=False)
     assert "Backup:" not in msg
     assert "Wrote:" in msg
+
+
+def test_format_diff_custom_labels():
+    current = {"mcpServers": {"test": {"command": "x", "args": []}}}
+    proposed = {"mcpServers": {}}
+    diff = format_diff(current, proposed, from_label="before", to_label="after")
+    assert "--- before" in diff
+    assert "+++ after" in diff
+
+
+def test_format_diff_custom_labels_none():
+    proposed = {"mcpServers": {"test": {}}}
+    diff = format_diff(None, proposed, to_label="after")
+    assert "+++ after" in diff
+    assert "(file does not exist; will be created)" in diff
+
+
+def test_revert_message():
+    msg = revert_message(Path("/tmp/config.json"), "diff here")
+    assert "Reverted: /tmp/config.json" in msg
+    assert "Removed:" in msg
+    assert "config.json.bak" in msg
+    assert "diff here" in msg
+    assert "Restart Claude Desktop" in msg
+
+
+def test_revert_message_empty_diff():
+    msg = revert_message(Path("/tmp/config.json"), "")
+    assert "Reverted:" in msg
+    assert "Restart Claude Desktop" in msg
+    # No extra blank line from empty diff
+    assert "\n\n\n" not in msg


### PR DESCRIPTION
Adds `cdcasasagi revert` to restore claude_desktop_config.json from the .bak file created by `add --write`. The command writes immediately (no --write flag needed since `add --write` serves as redo), shows a before/after diff, and deletes the .bak after successful restore.

---

## Summary
- Add `cdcasasagi revert` command that restores
`claude_desktop_config.json` from the `.bak` file created by `add --write`
- The command writes immediately (no `--write` flag needed since
re-running `add --write` serves as redo), displays a before/after diff,
and deletes the `.bak` after successful restore
- Refactor atomic write logic into `_atomic_write()` shared by both
`write_config` and `revert_config`

## Changes
- `desktop_config.py`: Add `BackupNotFoundError`, `BackupError`,
`backup_path()`, `load_backup()`, `_atomic_write()`, `revert_config()`
- `output.py`: Add `from_label`/`to_label` params to `format_diff()`, add
`revert_message()`
- `cli.py`: Add `revert` command
- Tests: 20 new tests (71 total, all passing)

## Test plan
- [x] `uv run pytest tests/ -v` — 71 tests pass
- [ ] Manual test: `cdcasasagi add <url> --write` then `cdcasasagi revert`
- [ ] Verify `.bak` is deleted after revert
- [ ] Verify config content matches pre-add state

🤖 Generated with [Claude Code](https://claude.com/claude-code)