### PR TITLE
Add mcp-server to generic subdomains

### DIFF
--- a/src/cdcasasagi/server_name.py
+++ b/src/cdcasasagi/server_name.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import ipaddress
 from urllib.parse import urlparse
 
-_GENERIC_SUBDOMAINS = {"mcp", "api", "app", "www"}
-_MCP_API_FRAGMENTS = {"mcp", "api"}
+_GENERIC_SUBDOMAINS = {"mcp", "mcp-server", "api", "app", "www"}
 
 
 class NameDerivationError(Exception):
@@ -30,11 +29,7 @@ def derive_server_name(url: str) -> str:
     sld = labels[-2]
     head = labels[0]
 
-    if (
-        head != sld
-        and head not in _GENERIC_SUBDOMAINS
-        and not any(frag in head for frag in _MCP_API_FRAGMENTS)
-    ):
+    if head != sld and head not in _GENERIC_SUBDOMAINS:
         candidate = head
     else:
         candidate = sld


### PR DESCRIPTION
## Summary
- `_GENERIC_SUBDOMAINS` に `"mcp-server"` を追加し、`mcp-server.example.com` のようなホスト名でSLD（例: `example`）を返すようにした
- `_MCP_API_FRAGMENTS` によるフラグメント部分一致チェックを削除し、サブドメイン判定を完全一致のみに簡素化

## Test plan
- [x] `mcp-server.egnyte.com` → `egnyte` を返すことを確認
- [x] 既存のテストケースがすべてパスすることを確認（16件全パス）

https://claude.ai/code/session_01VfTRz2HeGh3mtphbvJ35ba