### PR TITLE
Remove --transport option from import command

### DIFF
--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -177,7 +177,6 @@ def _validate_import_schema(raw_entries: list) -> list[str]:
 
 def _resolve_import_entries(
     raw_entries: list[dict],
-    default_transport: str,
     proxy_path: Path,
 ) -> list[tuple[str, str, dict]]:
     """Validate URLs, derive names, build config entries.
@@ -205,7 +204,7 @@ def _resolve_import_entries(
                 errors.append(f'entry[{i}]: {e}. Set "name" explicitly for this entry')
                 continue
 
-        transport = raw.get("transport", default_transport)
+        transport = raw.get("transport", "streamablehttp")
         entry = desktop_config.build_entry(proxy_path, transport, url)
         resolved.append((name, url, entry))
 
@@ -247,9 +246,6 @@ def _resolve_import_entries(
 @app.command(name="import")
 def import_cmd(
     file: str = typer.Argument(..., help="Path to JSON file (use - for stdin)"),
-    transport: str = typer.Option(
-        "streamablehttp", help="Default transport for entries without one"
-    ),
     force: bool = typer.Option(False, help="Overwrite existing entries on conflict"),
     write: bool = typer.Option(False, help="Actually write to the file"),
     verbose: bool = typer.Option(False, help="Show full diff in preview"),
@@ -268,7 +264,7 @@ def import_cmd(
         typer.echo("\n".join(schema_errors), err=True)
         raise typer.Exit(code=1)
 
-    resolved = _resolve_import_entries(raw_entries, transport, proxy_path)
+    resolved = _resolve_import_entries(raw_entries, proxy_path)
 
     cfg_path = desktop_config.config_path()
     try:


### PR DESCRIPTION
## Summary
- `import` コマンドから `--transport` オプションを削除
- 各エントリが JSON 内で個別に `transport` を指定でき、未指定時は `"streamablehttp"` にフォールバックするため、コマンドレベルのデフォルト上書きオプションは不要
- `_resolve_import_entries` の `default_transport` 引数も合わせて削除

## Test plan
- [x] `uv run ruff format` / `uv run ruff check` パス
- [x] `uv run pytest` 全122テストパス
- [ ] `cdcasasagi import servers.json` で `--transport` なしで動作確認
- [ ] エントリに `"transport": "sse"` を指定した場合にそちらが優先されることを確認

https://claude.ai/code/session_012CzhnokXaCGRT9pvW32Bg1