### PR TITLE
Switch import command from JSON array to JSON Lines format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Tests use `pytest` with `typer.testing.CliRunner`. The `config_env` fixture sets
 - Never modify top-level keys other than `mcpServers`.
 - Assume config structure is valid (Claude Desktop is using it). Only handle `mcpServers` key being absent (create as `{}`). Do not add handling for non-object JSON or non-dict `mcpServers` (see reverts `0f936eb`, `9a7cb75`).
 - Never fall back to PATH / `shutil.which` for `mcp-proxy`. Resolve from the same venv only.
-- Reject unknown keys in import JSON — never silently ignore.
+- Reject unknown keys in import JSONL — never silently ignore.
 
 ## Git Rules
 

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -117,7 +117,7 @@ def revert() -> None:
 
 
 def _parse_import_file(file_path: str) -> tuple[list, str]:
-    """Read and parse import JSON.  Returns ``(data, source_label)``."""
+    """Read and parse import JSONL.  Returns ``(data, source_label)``."""
     if file_path == "-":
         try:
             text = sys.stdin.read()
@@ -137,21 +137,37 @@ def _parse_import_file(file_path: str) -> tuple[list, str]:
             raise typer.Exit(code=1)
         source_label = file_path
 
-    try:
-        data = json.loads(text)
-    except json.JSONDecodeError as e:
-        typer.echo(f"Failed to parse JSON from {source_label}: {e}", err=True)
-        raise typer.Exit(code=1)
-
-    if not isinstance(data, list):
-        typer.echo("Input must be a JSON array of entries", err=True)
-        raise typer.Exit(code=1)
+    data = _parse_jsonl(text, source_label)
 
     if len(data) == 0:
         typer.echo("Input contains no entries", err=True)
         raise typer.Exit(code=1)
 
     return data, source_label
+
+
+def _parse_jsonl(text: str, source_label: str) -> list:
+    """Parse JSON Lines: one JSON value per non-blank line."""
+    lines = [line for line in text.splitlines() if line.strip()]
+    if not lines:
+        return []
+
+    entries = []
+    errors: list[str] = []
+    for i, line in enumerate(lines, 1):
+        try:
+            entries.append(json.loads(line))
+        except json.JSONDecodeError as e:
+            errors.append(f"line {i}: {e}")
+
+    if errors:
+        typer.echo(
+            f"Failed to parse JSON Lines from {source_label}:\n" + "\n".join(errors),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    return entries
 
 
 def _validate_import_schema(raw_entries: list) -> list[str]:
@@ -245,7 +261,7 @@ def _resolve_import_entries(
 
 @app.command(name="import")
 def import_cmd(
-    file: str = typer.Argument(..., help="Path to JSON file (use - for stdin)"),
+    file: str = typer.Argument(..., help="Path to JSONL file (use - for stdin)"),
     force: bool = typer.Option(False, help="Overwrite existing entries on conflict"),
     write: bool = typer.Option(False, help="Actually write to the file"),
     verbose: bool = typer.Option(False, help="Show full diff in preview"),

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -148,17 +148,20 @@ def _parse_import_file(file_path: str) -> tuple[list, str]:
 
 def _parse_jsonl(text: str, source_label: str) -> list:
     """Parse JSON Lines: one JSON value per non-blank line."""
-    lines = [line for line in text.splitlines() if line.strip()]
-    if not lines:
-        return []
-
     entries = []
     errors: list[str] = []
-    for i, line in enumerate(lines, 1):
+    has_content = False
+    for i, line in enumerate(text.splitlines(), 1):
+        if not line.strip():
+            continue
+        has_content = True
         try:
             entries.append(json.loads(line))
         except json.JSONDecodeError as e:
             errors.append(f"line {i}: {e}")
+
+    if not has_content:
+        return []
 
     if errors:
         typer.echo(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,14 +180,10 @@ class TestRevert:
 class TestImportPreview:
     def test_preview_basic(self, config_env, tmp_path):
         config_file, _ = config_env
-        input_file = tmp_path / "servers.json"
+        input_file = tmp_path / "servers.jsonl"
         input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                    {"url": "https://mcp.linear.app/mcp"},
-                ]
-            )
+            '{"url": "https://mcp.notion.com/mcp"}\n'
+            '{"url": "https://mcp.linear.app/mcp"}\n'
         )
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 0
@@ -199,13 +195,9 @@ class TestImportPreview:
 
     def test_preview_explicit_names(self, config_env, tmp_path):
         config_file, _ = config_env
-        input_file = tmp_path / "servers.json"
+        input_file = tmp_path / "servers.jsonl"
         input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp", "name": "my-notion"},
-                ]
-            )
+            '{"url": "https://mcp.notion.com/mcp", "name": "my-notion"}\n'
         )
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 0
@@ -213,13 +205,9 @@ class TestImportPreview:
 
     def test_preview_per_entry_transport(self, config_env, tmp_path):
         config_file, fake_proxy = config_env
-        input_file = tmp_path / "servers.json"
+        input_file = tmp_path / "servers.jsonl"
         input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp", "transport": "sse"},
-                ]
-            )
+            '{"url": "https://mcp.notion.com/mcp", "transport": "sse"}\n'
         )
         result = runner.invoke(app, ["import", str(input_file), "--write"])
         assert result.exit_code == 0
@@ -228,38 +216,43 @@ class TestImportPreview:
 
     def test_preview_verbose(self, config_env, tmp_path):
         config_file, _ = config_env
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file), "--verbose"])
         assert result.exit_code == 0
         assert "proposed" in result.output
 
     def test_preview_from_stdin(self, config_env):
         config_file, _ = config_env
-        stdin_data = json.dumps([{"url": "https://mcp.notion.com/mcp"}])
+        stdin_data = '{"url": "https://mcp.notion.com/mcp"}\n'
         result = runner.invoke(app, ["import", "-"], input=stdin_data)
         assert result.exit_code == 0
         assert "notion" in result.output
         assert "stdin" in result.output
 
+    def test_blank_lines_ignored(self, config_env, tmp_path):
+        config_file, _ = config_env
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text(
+            "\n"
+            '{"url": "https://mcp.notion.com/mcp"}\n'
+            "\n"
+            '{"url": "https://mcp.linear.app/mcp"}\n'
+            "\n"
+        )
+        result = runner.invoke(app, ["import", str(input_file)])
+        assert result.exit_code == 0
+        assert "notion" in result.output
+        assert "linear" in result.output
+
 
 class TestImportWrite:
     def test_write_creates_file(self, config_env, tmp_path):
         config_file, fake_proxy = config_env
-        input_file = tmp_path / "servers.json"
+        input_file = tmp_path / "servers.jsonl"
         input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                    {"url": "https://developers.openai.com/mcp"},
-                ]
-            )
+            '{"url": "https://mcp.notion.com/mcp"}\n'
+            '{"url": "https://developers.openai.com/mcp"}\n'
         )
         result = runner.invoke(app, ["import", str(input_file), "--write"])
         assert result.exit_code == 0
@@ -272,14 +265,8 @@ class TestImportWrite:
     def test_write_creates_backup(self, config_env, tmp_path):
         config_file, _ = config_env
         config_file.write_text(json.dumps({"mcpServers": {}}))
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file), "--write"])
         assert result.exit_code == 0
         assert config_file.with_suffix(".json.bak").exists()
@@ -289,14 +276,8 @@ class TestImportWrite:
         config_file.write_text(
             json.dumps({"mcpServers": {"old": {"command": "y"}}, "other": "keep"})
         )
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file), "--write"])
         assert result.exit_code == 0
         data = json.loads(config_file.read_text())
@@ -311,14 +292,8 @@ class TestImportWrite:
             "args": ["--transport", "streamablehttp", "https://mcp.notion.com/mcp"],
         }
         config_file.write_text(json.dumps({"mcpServers": {"notion": entry}}))
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file), "--write"])
         assert result.exit_code == 0
         assert "No changes needed" in result.output
@@ -330,14 +305,8 @@ class TestImportConflicts:
         config_file.write_text(
             json.dumps({"mcpServers": {"notion": {"command": "old"}}})
         )
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert "name conflict" in result.output
@@ -348,14 +317,8 @@ class TestImportConflicts:
         config_file.write_text(
             json.dumps({"mcpServers": {"notion": {"command": "old"}}})
         )
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file), "--force", "--write"])
         assert result.exit_code == 0
         data = json.loads(config_file.read_text())
@@ -368,67 +331,62 @@ class TestImportConflicts:
             "args": ["--transport", "streamablehttp", "https://mcp.notion.com/mcp"],
         }
         config_file.write_text(json.dumps({"mcpServers": {"notion": entry}}))
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 0
         assert "identical" in result.output
 
 
 class TestImportValidationErrors:
-    def test_invalid_json(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
+    def test_invalid_jsonl(self, config_env, tmp_path):
+        input_file = tmp_path / "servers.jsonl"
         input_file.write_text("not json")
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
-        assert "Failed to parse JSON" in result.output
+        assert "Failed to parse JSON Lines" in result.output
 
-    def test_not_array(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
-        input_file.write_text('{"url": "https://example.com"}')
+    def test_invalid_jsonl_line(self, config_env, tmp_path):
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\nnot json\n')
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
-        assert "JSON array" in result.output
+        assert "Failed to parse JSON Lines" in result.output
+        assert "line 2" in result.output
 
-    def test_empty_array(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
-        input_file.write_text("[]")
+    def test_empty_input(self, config_env, tmp_path):
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text("")
+        result = runner.invoke(app, ["import", str(input_file)])
+        assert result.exit_code == 1
+        assert "no entries" in result.output
+
+    def test_blank_lines_only(self, config_env, tmp_path):
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text("\n\n\n")
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert "no entries" in result.output
 
     def test_missing_url(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(json.dumps([{"name": "test"}]))
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"name": "test"}\n')
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert 'entry[0]: missing required key "url"' in result.output
 
     def test_unknown_keys(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps([{"url": "https://mcp.notion.com/mcp", "typo": "bad"}])
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp", "typo": "bad"}\n')
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert "unknown keys" in result.output
         assert "typo" in result.output
 
     def test_multiple_schema_errors(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
+        input_file = tmp_path / "servers.jsonl"
         input_file.write_text(
-            json.dumps(
-                [
-                    {"name": "test"},
-                    {"url": "https://example.com", "bad": "key"},
-                ]
-            )
+            '{"name": "test"}\n{"url": "https://example.com", "bad": "key"}\n'
         )
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
@@ -436,88 +394,62 @@ class TestImportValidationErrors:
         assert "entry[1]" in result.output
 
     def test_duplicate_names(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
+        input_file = tmp_path / "servers.jsonl"
         input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp", "name": "test"},
-                    {"url": "https://mcp.linear.app/mcp", "name": "test"},
-                ]
-            )
+            '{"url": "https://mcp.notion.com/mcp", "name": "test"}\n'
+            '{"url": "https://mcp.linear.app/mcp", "name": "test"}\n'
         )
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert 'Duplicate name "test"' in result.output
 
     def test_duplicate_urls(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
+        input_file = tmp_path / "servers.jsonl"
         input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp", "name": "a"},
-                    {"url": "https://mcp.notion.com/mcp", "name": "b"},
-                ]
-            )
+            '{"url": "https://mcp.notion.com/mcp", "name": "a"}\n'
+            '{"url": "https://mcp.notion.com/mcp", "name": "b"}\n'
         )
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert "Duplicate url" in result.output
 
     def test_invalid_url_scheme(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "ftp://example.com/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "ftp://example.com/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert "HTTP(S) URL" in result.output
 
     def test_name_derivation_failure(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://localhost/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://localhost/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert '"name"' in result.output
 
     def test_file_not_found(self, config_env, tmp_path):
-        result = runner.invoke(app, ["import", str(tmp_path / "nonexistent.json")])
+        result = runner.invoke(app, ["import", str(tmp_path / "nonexistent.jsonl")])
         assert result.exit_code == 1
         assert "File not found" in result.output
 
     def test_invalid_config_json(self, config_env, tmp_path):
         config_file, _ = config_env
         config_file.write_text("not json")
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(
-            json.dumps(
-                [
-                    {"url": "https://mcp.notion.com/mcp"},
-                ]
-            )
-        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert "Failed to parse JSON config" in result.output
 
     def test_entry_not_object(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
-        input_file.write_text(json.dumps(["https://mcp.notion.com/mcp"]))
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('"https://mcp.notion.com/mcp"\n')
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert "entry[0]: must be an object" in result.output
 
     def test_non_utf8_file(self, config_env, tmp_path):
-        input_file = tmp_path / "servers.json"
+        input_file = tmp_path / "servers.jsonl"
         input_file.write_bytes(b"\xff\xfe invalid utf-8")
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -354,6 +354,15 @@ class TestImportValidationErrors:
         assert "Failed to parse JSON Lines" in result.output
         assert "line 2" in result.output
 
+    def test_invalid_line_after_blank_reports_correct_line_number(
+        self, config_env, tmp_path
+    ):
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n\nnot json\n')
+        result = runner.invoke(app, ["import", str(input_file)])
+        assert result.exit_code == 1
+        assert "line 3" in result.output
+
     def test_empty_input(self, config_env, tmp_path):
         input_file = tmp_path / "servers.jsonl"
         input_file.write_text("")


### PR DESCRIPTION
## Summary
- `import` コマンドの入力形式を JSON 配列から JSONL（1行1JSONオブジェクト）に変更
- 空行はスキップされ、パースエラーは行番号付きでレポートされます
- まだユーザに公開していない機能のため、JSON 配列サポートは削除

## Example
```
{"url": "https://developers.openai.com/mcp", "name": "openai-developer-docs"}
{"url": "https://mcp.deepwiki.com/mcp"}
```

## Test plan
- [x] JSONL 入力のテスト（ファイル、stdin、空行スキップ、単一オブジェクト）がパス
- [x] バリデーションエラーテスト（不正JSONL、空入力、スキーマエラー等）がパス
- [x] 競合・上書き・同一テストがパス
- [x] `uv run ruff format` / `uv run ruff check` / `uv run pytest` すべてパス（124 tests passed）

https://claude.ai/code/session_01BsBzPiaqwrhd4sWXstYivQ