### PR TITLE
docs: Add git push workaround for Claude Code on the Web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,5 +5,6 @@
 - Prefer `gh` CLI over MCP servers. Always pass `-R ftnext/cdcasasagi` to `gh` commands.
 - The default git remote URL points to a local proxy that lacks push permissions. Before `git push`, fix the remote URL:
   ```bash
-  git remote set-url origin "https://ftnext:$(gh auth token)@github.com/ftnext/cdcasasagi.git"
+  gh auth setup-git
+  git remote set-url origin https://github.com/ftnext/cdcasasagi.git
   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,7 @@
 ## Claude Code on the Web
 
 - Prefer `gh` CLI over MCP servers. Always pass `-R ftnext/cdcasasagi` to `gh` commands.
+- The default git remote URL points to a local proxy that lacks push permissions. Before `git push`, fix the remote URL:
+  ```bash
+  git remote set-url origin "https://ftnext:$(gh auth token)@github.com/ftnext/cdcasasagi.git"
+  ```


### PR DESCRIPTION
The default remote URL uses a local proxy that lacks push permissions. Document the remote URL fix using gh auth token.

https://claude.ai/code/session_012CzhnokXaCGRT9pvW32Bg1