### PR TITLE
Add version subcommand

### DIFF
--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -17,6 +18,11 @@ app = typer.Typer(pretty_exceptions_enable=False)
 @app.callback()
 def _callback() -> None:
     pass
+
+
+@app.command()
+def version() -> None:
+    typer.echo(_pkg_version("cdcasasagi"))
 
 
 def _validate_url(url: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+from importlib.metadata import version as pkg_version
 
 import pytest
 from typer.testing import CliRunner
@@ -20,6 +21,13 @@ def config_env(tmp_path, monkeypatch):
 
     monkeypatch.setattr("cdcasasagi.mcp_proxy.sys.executable", str(fake_python))
     return config_file, fake_proxy
+
+
+class TestVersion:
+    def test_version(self):
+        result = runner.invoke(app, ["version"])
+        assert result.exit_code == 0
+        assert result.output.strip() == pkg_version("cdcasasagi")
 
 
 class TestAddPreview:


### PR DESCRIPTION
## Summary
- Add `cdcasasagi version` subcommand that prints the package version
- Use `importlib.metadata.version()` to retrieve the version at runtime, since setuptools dynamic metadata is not supported by uv build

## Test plan
- [x] `uv run pytest` passes (123 tests)
- [x] `uv run ruff check` and `uv run ruff format` pass
- [ ] `cdcasasagi version` prints the correct version string

https://claude.ai/code/session_01JGeiD1bCUdsfhJfRVfpJEu