### PR TITLE
Reject duplicate URLs in add command

### DIFF
--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -72,8 +72,8 @@ def add(
     entry = desktop_config.build_entry(proxy_path, transport, url)
 
     try:
-        merged = desktop_config.merge_entry(current_config, name, entry, force)
-    except desktop_config.EntryExistsError as e:
+        merged = desktop_config.merge_entry(current_config, name, entry, force, url=url)
+    except (desktop_config.EntryExistsError, desktop_config.DuplicateUrlError) as e:
         typer.echo(str(e), err=True)
         raise typer.Exit(code=1)
 

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -21,6 +21,10 @@ class BackupNotFoundError(Exception):
     pass
 
 
+class DuplicateUrlError(Exception):
+    pass
+
+
 class BackupError(Exception):
     pass
 
@@ -74,6 +78,15 @@ def load_backup(path: Path) -> dict[str, Any]:
         ) from e
 
 
+def find_entry_name_by_url(config: dict[str, Any], url: str) -> str | None:
+    """Return the name of the entry whose args end with *url*, or ``None``."""
+    for name, entry in config.get("mcpServers", {}).items():
+        args = entry.get("args", [])
+        if args and args[-1] == url:
+            return name
+    return None
+
+
 def build_entry(mcp_proxy_path: Path, transport: str, url: str) -> dict[str, Any]:
     return {
         "command": str(mcp_proxy_path),
@@ -86,10 +99,21 @@ def merge_entry(
     name: str,
     entry: dict[str, Any],
     force: bool,
+    *,
+    url: str | None = None,
 ) -> dict[str, Any]:
     config = json.loads(json.dumps(config))  # deep copy
     if "mcpServers" not in config:
         config["mcpServers"] = {}
+
+    if url is not None:
+        existing = find_entry_name_by_url(config, url)
+        if existing is not None and existing != name:
+            if not force:
+                raise DuplicateUrlError(
+                    f'URL already configured as "{existing}". Use --force to overwrite'
+                )
+            del config["mcpServers"][existing]
 
     if name in config["mcpServers"] and not force:
         raise EntryExistsError(f'"{name}" already exists. Use --force to overwrite')

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -78,13 +78,14 @@ def load_backup(path: Path) -> dict[str, Any]:
         ) from e
 
 
-def find_entry_name_by_url(config: dict[str, Any], url: str) -> str | None:
-    """Return the name of the entry whose args end with *url*, or ``None``."""
+def find_entry_names_by_url(config: dict[str, Any], url: str) -> list[str]:
+    """Return names of all entries whose args end with *url*."""
+    names: list[str] = []
     for name, entry in config.get("mcpServers", {}).items():
         args = entry.get("args", [])
         if args and args[-1] == url:
-            return name
-    return None
+            names.append(name)
+    return names
 
 
 def build_entry(mcp_proxy_path: Path, transport: str, url: str) -> dict[str, Any]:
@@ -107,13 +108,14 @@ def merge_entry(
         config["mcpServers"] = {}
 
     if url is not None:
-        existing = find_entry_name_by_url(config, url)
-        if existing is not None and existing != name:
+        others = [n for n in find_entry_names_by_url(config, url) if n != name]
+        if others:
             if not force:
                 raise DuplicateUrlError(
-                    f'URL already configured as "{existing}". Use --force to overwrite'
+                    f'URL already configured as "{others[0]}". Use --force to overwrite'
                 )
-            del config["mcpServers"][existing]
+            for n in others:
+                del config["mcpServers"][n]
 
     if name in config["mcpServers"] and not force:
         raise EntryExistsError(f'"{name}" already exists. Use --force to overwrite')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,52 @@ class TestAddErrors:
         data = json.loads(config_file.read_text())
         assert data["mcpServers"]["notion"]["command"] != "old"
 
+    def test_duplicate_url_different_name(self, config_env):
+        config_file, fake_proxy = config_env
+        entry = {
+            "command": str(fake_proxy),
+            "args": [
+                "--transport",
+                "streamablehttp",
+                "https://mcp.notion.com/mcp",
+            ],
+        }
+        config_file.write_text(json.dumps({"mcpServers": {"notion": entry}}))
+        result = runner.invoke(
+            app, ["add", "https://mcp.notion.com/mcp", "--name", "my-notion"]
+        )
+        assert result.exit_code == 1
+        assert "already configured" in result.output
+        assert '"notion"' in result.output
+        assert "--force" in result.output
+
+    def test_duplicate_url_with_force(self, config_env):
+        config_file, fake_proxy = config_env
+        entry = {
+            "command": str(fake_proxy),
+            "args": [
+                "--transport",
+                "streamablehttp",
+                "https://mcp.notion.com/mcp",
+            ],
+        }
+        config_file.write_text(json.dumps({"mcpServers": {"notion": entry}}))
+        result = runner.invoke(
+            app,
+            [
+                "add",
+                "https://mcp.notion.com/mcp",
+                "--name",
+                "my-notion",
+                "--force",
+                "--write",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        assert "my-notion" in data["mcpServers"]
+        assert "notion" not in data["mcpServers"]
+
     def test_invalid_json_config(self, config_env):
         config_file, _ = config_env
         config_file.write_text("not json")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,6 +158,28 @@ class TestAddErrors:
         assert "my-notion" in data["mcpServers"]
         assert "notion" not in data["mcpServers"]
 
+    def test_duplicate_url_force_removes_all(self, config_env):
+        config_file, fake_proxy = config_env
+        url = "https://mcp.notion.com/mcp"
+        entry = {
+            "command": str(fake_proxy),
+            "args": ["--transport", "streamablehttp", url],
+        }
+        config_file.write_text(
+            json.dumps(
+                {"mcpServers": {"notion-a": entry, "notion-b": entry, "other": {}}}
+            )
+        )
+        result = runner.invoke(
+            app, ["add", url, "--name", "notion", "--force", "--write"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        assert "notion" in data["mcpServers"]
+        assert "notion-a" not in data["mcpServers"]
+        assert "notion-b" not in data["mcpServers"]
+        assert "other" in data["mcpServers"]
+
     def test_invalid_json_config(self, config_env):
         config_file, _ = config_env
         config_file.write_text("not json")


### PR DESCRIPTION
## Summary

- `add` command now errors when the given URL is already configured under a different name, preventing silent duplicates
- `--force` removes the old entry and adds the new one under the requested name
- Added `DuplicateUrlError` and `find_entry_name_by_url` to `desktop_config.py`

## Test plan

- [x] `test_duplicate_url_different_name` — URL already exists under different name → exit code 1, message includes existing name and `--force` hint
- [x] `test_duplicate_url_with_force` — same scenario with `--force --write` → old entry removed, new entry added
- [x] Existing duplicate-name tests still pass
- [x] All 128 tests pass

https://claude.ai/code/session_01DC5bKTr2yUD9fNqciEhK7X