### PR TITLE
Add doctor command to check setup prerequisites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ uv build                                       # Build package
 
 `src/cdcasasagi/` with src layout. Entry point: `cdcasasagi:main` → `cli.app` (Typer).
 
-- `cli.py` — CLI commands: `add`, `import`, `revert`
+- `cli.py` — CLI commands: `add`, `doctor`, `import`, `revert`
 - `desktop_config.py` — Config file I/O, entry merging, import planning, atomic writes with `.bak` backups
 - `mcp_proxy.py` — Locates `mcp-proxy` binary in the same venv
 - `server_name.py` — Derives server name from URL hostname

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -23,6 +24,33 @@ def _callback() -> None:
 @app.command()
 def version() -> None:
     typer.echo(_pkg_version("cdcasasagi"))
+
+
+@app.command()
+def doctor() -> None:
+    results: list[tuple[str, bool, str]] = []
+
+    try:
+        proxy_path = mcp_proxy.resolve_path()
+        results.append(("mcp-proxy", True, str(proxy_path)))
+    except mcp_proxy.McpProxyNotFoundError:
+        results.append(("mcp-proxy", False, "not found"))
+
+    cfg_path = desktop_config.config_path()
+    if cfg_path.exists():
+        results.append(("Config file", True, str(cfg_path)))
+    else:
+        results.append(("Config file", False, f"not found: {cfg_path}"))
+
+    cfg_dir = cfg_path.parent
+    if os.access(cfg_dir, os.W_OK):
+        results.append(("Config directory", True, str(cfg_dir)))
+    else:
+        results.append(("Config directory", False, f"not writable: {cfg_dir}"))
+
+    typer.echo(output.doctor_message(results))
+    if not all(passed for _, passed, _ in results):
+        raise typer.Exit(code=1)
 
 
 def _validate_url(url: str) -> None:

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -37,7 +37,7 @@ def doctor() -> None:
         results.append(("mcp-proxy", False, "not found"))
 
     cfg_path = desktop_config.config_path()
-    if cfg_path.exists():
+    if cfg_path.is_file():
         results.append(("Config file", True, str(cfg_path)))
     else:
         results.append(("Config file", False, f"not found: {cfg_path}"))

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -204,3 +204,19 @@ def import_write_message(
     lines.append(f"{action_text} {entry_word}. Restart Claude Desktop to take effect.")
 
     return "\n".join(lines)
+
+
+def doctor_message(results: list[tuple[str, bool, str]]) -> str:
+    lines: list[str] = []
+    for label, passed, detail in results:
+        tag = "[PASS]" if passed else "[FAIL]"
+        lines.append(f"{tag} {label}: {detail}")
+    lines.append("")
+    fail_count = sum(1 for _, passed, _ in results if not passed)
+    if fail_count == 0:
+        lines.append("All checks passed.")
+    elif fail_count == 1:
+        lines.append("1 check failed. See above for details.")
+    else:
+        lines.append(f"{fail_count} checks failed. See above for details.")
+    return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import os
 from importlib.metadata import version as pkg_version
 
 import pytest
@@ -28,6 +29,64 @@ class TestVersion:
         result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
         assert result.output.strip() == pkg_version("cdcasasagi")
+
+
+class TestDoctor:
+    def test_all_pass(self, config_env):
+        config_file, fake_proxy = config_env
+        config_file.write_text('{"mcpServers": {}}')
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert result.output.count("[PASS]") == 3
+        assert "[FAIL]" not in result.output
+        assert "All checks passed." in result.output
+
+    def test_mcp_proxy_missing(self, config_env, monkeypatch):
+        config_file, _ = config_env
+        config_file.write_text('{"mcpServers": {}}')
+        # Point sys.executable to a dir without mcp-proxy
+        monkeypatch.setattr(
+            "cdcasasagi.mcp_proxy.sys.executable", "/nonexistent/bin/python"
+        )
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 1
+        assert "[FAIL] mcp-proxy:" in result.output
+        # Other checks still run
+        assert result.output.count("[PASS]") == 2
+
+    def test_config_file_missing(self, config_env):
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 1
+        assert "[FAIL] Config file:" in result.output
+        assert "[PASS] mcp-proxy:" in result.output
+
+    def test_config_dir_not_writable(self, config_env, monkeypatch):
+        config_file, _ = config_env
+        config_file.write_text('{"mcpServers": {}}')
+        original_access = os.access
+
+        def fake_access(path, mode, **kwargs):
+            if mode == os.W_OK:
+                return False
+            return original_access(path, mode, **kwargs)
+
+        monkeypatch.setattr("os.access", fake_access)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 1
+        assert "[FAIL] Config directory:" in result.output
+        assert "not writable" in result.output
+
+    def test_all_checks_run_even_with_failures(self, config_env, monkeypatch):
+        # mcp-proxy missing + config file missing
+        monkeypatch.setattr(
+            "cdcasasagi.mcp_proxy.sys.executable", "/nonexistent/bin/python"
+        )
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 1
+        # All 3 check lines present
+        assert "mcp-proxy:" in result.output
+        assert "Config file:" in result.output
+        assert "Config directory:" in result.output
 
 
 class TestAddPreview:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from cdcasasagi.output import (
+    doctor_message,
     format_diff,
     import_preview_message,
     import_write_message,
@@ -239,3 +240,53 @@ class TestImportWriteMessage:
             file_existed=False,
         )
         assert "1 entry" in msg
+
+
+class TestDoctorMessage:
+    def test_all_pass(self):
+        results = [
+            ("mcp-proxy", True, "/usr/local/bin/mcp-proxy"),
+            ("Config file", True, "/tmp/config.json"),
+            ("Config directory", True, "/tmp"),
+        ]
+        msg = doctor_message(results)
+        assert msg.count("[PASS]") == 3
+        assert "[FAIL]" not in msg
+        assert "All checks passed." in msg
+
+    def test_one_failure(self):
+        results = [
+            ("mcp-proxy", True, "/usr/local/bin/mcp-proxy"),
+            ("Config file", False, "not found: /tmp/config.json"),
+            ("Config directory", True, "/tmp"),
+        ]
+        msg = doctor_message(results)
+        assert msg.count("[PASS]") == 2
+        assert msg.count("[FAIL]") == 1
+        assert "1 check failed." in msg
+
+    def test_multiple_failures(self):
+        results = [
+            ("mcp-proxy", False, "not found"),
+            ("Config file", False, "not found: /tmp/config.json"),
+            ("Config directory", False, "not writable: /tmp"),
+        ]
+        msg = doctor_message(results)
+        assert msg.count("[FAIL]") == 3
+        assert "3 checks failed." in msg
+
+    def test_detail_shown(self):
+        results = [
+            ("mcp-proxy", True, "/path/to/mcp-proxy"),
+        ]
+        msg = doctor_message(results)
+        assert "/path/to/mcp-proxy" in msg
+
+    def test_ascii_only(self):
+        results = [
+            ("mcp-proxy", True, "/usr/local/bin/mcp-proxy"),
+            ("Config file", False, "not found: /tmp/config.json"),
+            ("Config directory", True, "/tmp"),
+        ]
+        msg = doctor_message(results)
+        assert msg.isascii()


### PR DESCRIPTION
## Summary
- Add `doctor` command that checks three setup prerequisites: mcp-proxy binary existence, config file existence, and config directory writability
- All checks always run (no early abort), exit 0 if all pass, exit 1 if any fail
- Output uses ASCII-only `[PASS]`/`[FAIL]` markers per design rules

## Test plan
- [x] Unit tests for `doctor_message()` formatting in `test_output.py`
- [x] Integration tests for `doctor` command in `test_cli.py` (all pass, proxy missing, config missing, dir not writable, all checks run even with failures)
- [x] All 139 tests pass
- [x] Smoke test: `uv run cdcasasagi doctor`

https://claude.ai/code/session_01NRvH8C2aFc294DAejwBism