### PR TITLE
Add validate command for JSONL import files

### DIFF
--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -302,12 +302,12 @@ def _resolve_import_entries(
 
 
 # ------------------------------------------------------------------
-# validate command
+# validate-import command
 # ------------------------------------------------------------------
 
 
-@app.command()
-def validate(
+@app.command(name="validate-import")
+def validate_import(
     file: str = typer.Argument(..., help="Path to JSONL file (use - for stdin)"),
 ) -> None:
     """Validate a JSONL import file without importing."""

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -228,16 +228,17 @@ def _validate_import_schema(raw_entries: list) -> list[str]:
     return errors
 
 
-def _resolve_import_entries(
+def _collect_entry_errors(
     raw_entries: list[dict],
-    proxy_path: Path,
-) -> list[tuple[str, str, dict]]:
-    """Validate URLs, derive names, build config entries.
+) -> tuple[list[str], list[tuple[str, str, str]]]:
+    """Validate URLs, derive names, check duplicates.  No entry building.
 
-    Returns list of ``(name, url, entry_dict)``.
+    Returns ``(errors, validated)`` where *validated* contains
+    ``(name, url, transport)`` tuples for entries that passed individual
+    validation.
     """
     errors: list[str] = []
-    resolved: list[tuple[str, str, dict]] = []
+    validated: list[tuple[str, str, str]] = []
 
     for i, raw in enumerate(raw_entries):
         url = raw["url"]
@@ -258,37 +259,78 @@ def _resolve_import_entries(
                 continue
 
         transport = raw.get("transport", "streamablehttp")
-        entry = desktop_config.build_entry(proxy_path, transport, url)
-        resolved.append((name, url, entry))
-
-    if errors:
-        typer.echo("\n".join(errors), err=True)
-        raise typer.Exit(code=1)
+        validated.append((name, url, transport))
 
     # Duplicate checks within the input
-    dup_errors: list[str] = []
     names_seen: dict[str, int] = {}
     urls_seen: dict[str, int] = {}
 
-    for i, (name, url, _) in enumerate(resolved):
+    for i, (name, url, _) in enumerate(validated):
         if name in names_seen:
-            dup_errors.append(
+            errors.append(
                 f'Duplicate name "{name}" in entry[{names_seen[name]}] and entry[{i}]'
             )
         else:
             names_seen[name] = i
         if url in urls_seen:
-            dup_errors.append(
+            errors.append(
                 f'Duplicate url "{url}" in entry[{urls_seen[url]}] and entry[{i}]'
             )
         else:
             urls_seen[url] = i
 
-    if dup_errors:
-        typer.echo("\n".join(dup_errors), err=True)
+    return errors, validated
+
+
+def _resolve_import_entries(
+    raw_entries: list[dict],
+    proxy_path: Path,
+) -> list[tuple[str, str, dict]]:
+    """Validate URLs, derive names, build config entries.
+
+    Returns list of ``(name, url, entry_dict)``.
+    """
+    errors, validated = _collect_entry_errors(raw_entries)
+    if errors:
+        typer.echo("\n".join(errors), err=True)
         raise typer.Exit(code=1)
 
-    return resolved
+    return [
+        (name, url, desktop_config.build_entry(proxy_path, transport, url))
+        for name, url, transport in validated
+    ]
+
+
+# ------------------------------------------------------------------
+# validate command
+# ------------------------------------------------------------------
+
+
+@app.command()
+def validate(
+    file: str = typer.Argument(..., help="Path to JSONL file (use - for stdin)"),
+) -> None:
+    """Validate a JSONL import file without importing."""
+    raw_entries, source_label = _parse_import_file(file)
+
+    schema_errors = _validate_import_schema(raw_entries)
+
+    if not schema_errors:
+        entry_errors, validated = _collect_entry_errors(raw_entries)
+    else:
+        entry_errors = []
+        validated = []
+
+    all_errors = schema_errors + entry_errors
+
+    if all_errors:
+        typer.echo(
+            output.validate_error_message(source_label, len(raw_entries), all_errors),
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    typer.echo(output.validate_ok_message(source_label, len(raw_entries), validated))
 
 
 # ------------------------------------------------------------------

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -206,6 +206,35 @@ def import_write_message(
     return "\n".join(lines)
 
 
+def validate_ok_message(
+    source: str,
+    entry_count: int,
+    resolved: list[tuple[str, str, str]],
+) -> str:
+    entry_word = "entry" if entry_count == 1 else "entries"
+    lines: list[str] = [f"Valid: {source} ({entry_count} {entry_word})", ""]
+    max_name = max((len(n) for n, _, _ in resolved), default=0)
+    for name, url, _transport in resolved:
+        lines.append(f"  {name.ljust(max_name)}  {url}")
+    return "\n".join(lines)
+
+
+def validate_error_message(
+    source: str,
+    entry_count: int,
+    errors: list[str],
+) -> str:
+    entry_word = "entry" if entry_count == 1 else "entries"
+    error_word = "error" if len(errors) == 1 else "errors"
+    lines: list[str] = [
+        f"Invalid: {source} ({entry_count} {entry_word}, {len(errors)} {error_word})",
+        "",
+    ]
+    for e in errors:
+        lines.append(f"  {e}")
+    return "\n".join(lines)
+
+
 def doctor_message(results: list[tuple[str, bool, str]]) -> str:
     lines: list[str] = []
     for label, passed, detail in results:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,7 +615,7 @@ class TestValidate:
     def test_single_entry(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 0
         assert "Valid:" in result.output
         assert "1 entry" in result.output
@@ -627,7 +627,7 @@ class TestValidate:
             '{"url": "https://mcp.notion.com/mcp"}\n'
             '{"url": "https://mcp.linear.app/mcp"}\n'
         )
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 0
         assert "2 entries" in result.output
         assert "notion" in result.output
@@ -636,7 +636,7 @@ class TestValidate:
     def test_explicit_name(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"url": "https://mcp.notion.com/mcp", "name": "my-notion"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 0
         assert "my-notion" in result.output
 
@@ -645,13 +645,13 @@ class TestValidate:
         f.write_text(
             '{"url": "https://example.com/mcp", "name": "test", "transport": "sse"}\n'
         )
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 0
 
     def test_blank_lines_skipped(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('\n{"url": "https://mcp.notion.com/mcp"}\n\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 0
         assert "1 entry" in result.output
 
@@ -664,19 +664,19 @@ class TestValidate:
         )
         f = tmp_path / "servers.jsonl"
         f.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 0
 
     def test_does_not_require_config_file(self, validate_env, tmp_path):
         """validate works even when config file does not exist."""
         f = tmp_path / "servers.jsonl"
         f.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 0
 
     def test_stdin(self, validate_env):
         result = runner.invoke(
-            app, ["validate", "-"], input='{"url": "https://mcp.notion.com/mcp"}\n'
+            app, ["validate-import", "-"], input='{"url": "https://mcp.notion.com/mcp"}\n'
         )
         assert result.exit_code == 0
         assert "Valid:" in result.output
@@ -687,28 +687,28 @@ class TestValidateErrors:
     def test_invalid_jsonl(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text("not json")
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "Failed to parse JSON Lines" in result.output
 
     def test_empty_file(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text("")
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "no entries" in result.output
 
     def test_blank_lines_only(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text("\n\n\n")
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "no entries" in result.output
 
     def test_missing_url(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"name": "test"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "Invalid:" in result.output
         assert 'entry[0]: missing required key "url"' in result.output
@@ -716,7 +716,7 @@ class TestValidateErrors:
     def test_unknown_keys(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"url": "https://mcp.notion.com/mcp", "typo": "bad"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "unknown keys" in result.output
         assert "typo" in result.output
@@ -724,28 +724,28 @@ class TestValidateErrors:
     def test_entry_not_object(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('"https://mcp.notion.com/mcp"\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "entry[0]: must be an object" in result.output
 
     def test_url_not_string(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"url": 123}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert '"url" must be a string' in result.output
 
     def test_name_not_string(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"url": "https://mcp.notion.com/mcp", "name": 123}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert '"name" must be a string' in result.output
 
     def test_multiple_schema_errors(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"name": "test"}\n{"url": "https://example.com", "bad": "key"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "entry[0]" in result.output
         assert "entry[1]" in result.output
@@ -753,14 +753,14 @@ class TestValidateErrors:
     def test_invalid_url_scheme(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"url": "ftp://example.com/mcp"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "HTTP(S) URL" in result.output
 
     def test_name_derivation_failure(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"url": "https://localhost/mcp"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert '"name"' in result.output
 
@@ -770,7 +770,7 @@ class TestValidateErrors:
             '{"url": "https://mcp.notion.com/mcp", "name": "test"}\n'
             '{"url": "https://mcp.linear.app/mcp", "name": "test"}\n'
         )
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert 'Duplicate name "test"' in result.output
 
@@ -780,26 +780,26 @@ class TestValidateErrors:
             '{"url": "https://mcp.notion.com/mcp", "name": "a"}\n'
             '{"url": "https://mcp.notion.com/mcp", "name": "b"}\n'
         )
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "Duplicate url" in result.output
 
     def test_file_not_found(self, validate_env, tmp_path):
-        result = runner.invoke(app, ["validate", str(tmp_path / "nonexistent.jsonl")])
+        result = runner.invoke(app, ["validate-import", str(tmp_path / "nonexistent.jsonl")])
         assert result.exit_code == 1
         assert "File not found" in result.output
 
     def test_non_utf8_file(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_bytes(b"\xff\xfe invalid utf-8")
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "Cannot read file" in result.output
 
     def test_error_output_format(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"
         f.write_text('{"name": "test"}\n{"url": "ftp://bad.com"}\n')
-        result = runner.invoke(app, ["validate", str(f)])
+        result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 1
         assert "Invalid:" in result.output
         assert "2 entries" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -598,3 +598,208 @@ class TestImportValidationErrors:
         result = runner.invoke(app, ["import", str(input_file)])
         assert result.exit_code == 1
         assert "Cannot read file" in result.output
+
+
+# ------------------------------------------------------------------
+# validate command
+# ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def validate_env(tmp_path, monkeypatch):
+    """Minimal env for validate — no mcp-proxy, no config file."""
+    monkeypatch.setenv("CLAUDE_DESKTOP_CONFIG", str(tmp_path / "nonexistent.json"))
+
+
+class TestValidate:
+    def test_single_entry(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 0
+        assert "Valid:" in result.output
+        assert "1 entry" in result.output
+        assert "mcp.notion.com" in result.output
+
+    def test_multiple_entries(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text(
+            '{"url": "https://mcp.notion.com/mcp"}\n'
+            '{"url": "https://mcp.linear.app/mcp"}\n'
+        )
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 0
+        assert "2 entries" in result.output
+        assert "notion" in result.output
+        assert "linear" in result.output
+
+    def test_explicit_name(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": "https://mcp.notion.com/mcp", "name": "my-notion"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 0
+        assert "my-notion" in result.output
+
+    def test_explicit_transport(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text(
+            '{"url": "https://example.com/mcp", "name": "test", "transport": "sse"}\n'
+        )
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 0
+
+    def test_blank_lines_skipped(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('\n{"url": "https://mcp.notion.com/mcp"}\n\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 0
+        assert "1 entry" in result.output
+
+    def test_does_not_require_mcp_proxy(self, tmp_path, monkeypatch):
+        """validate works even when mcp-proxy is not installed."""
+        monkeypatch.setenv("CLAUDE_DESKTOP_CONFIG", str(tmp_path / "no.json"))
+        # Point sys.executable somewhere with no mcp-proxy
+        monkeypatch.setattr(
+            "cdcasasagi.mcp_proxy.sys.executable", str(tmp_path / "nope" / "python")
+        )
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 0
+
+    def test_does_not_require_config_file(self, validate_env, tmp_path):
+        """validate works even when config file does not exist."""
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 0
+
+    def test_stdin(self, validate_env):
+        result = runner.invoke(
+            app, ["validate", "-"], input='{"url": "https://mcp.notion.com/mcp"}\n'
+        )
+        assert result.exit_code == 0
+        assert "Valid:" in result.output
+        assert "stdin" in result.output
+
+
+class TestValidateErrors:
+    def test_invalid_jsonl(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text("not json")
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "Failed to parse JSON Lines" in result.output
+
+    def test_empty_file(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text("")
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "no entries" in result.output
+
+    def test_blank_lines_only(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text("\n\n\n")
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "no entries" in result.output
+
+    def test_missing_url(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"name": "test"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "Invalid:" in result.output
+        assert 'entry[0]: missing required key "url"' in result.output
+
+    def test_unknown_keys(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": "https://mcp.notion.com/mcp", "typo": "bad"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "unknown keys" in result.output
+        assert "typo" in result.output
+
+    def test_entry_not_object(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('"https://mcp.notion.com/mcp"\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "entry[0]: must be an object" in result.output
+
+    def test_url_not_string(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": 123}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert '"url" must be a string' in result.output
+
+    def test_name_not_string(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": "https://mcp.notion.com/mcp", "name": 123}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert '"name" must be a string' in result.output
+
+    def test_multiple_schema_errors(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"name": "test"}\n{"url": "https://example.com", "bad": "key"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "entry[0]" in result.output
+        assert "entry[1]" in result.output
+
+    def test_invalid_url_scheme(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": "ftp://example.com/mcp"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "HTTP(S) URL" in result.output
+
+    def test_name_derivation_failure(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": "https://localhost/mcp"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert '"name"' in result.output
+
+    def test_duplicate_names(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text(
+            '{"url": "https://mcp.notion.com/mcp", "name": "test"}\n'
+            '{"url": "https://mcp.linear.app/mcp", "name": "test"}\n'
+        )
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert 'Duplicate name "test"' in result.output
+
+    def test_duplicate_urls(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text(
+            '{"url": "https://mcp.notion.com/mcp", "name": "a"}\n'
+            '{"url": "https://mcp.notion.com/mcp", "name": "b"}\n'
+        )
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "Duplicate url" in result.output
+
+    def test_file_not_found(self, validate_env, tmp_path):
+        result = runner.invoke(app, ["validate", str(tmp_path / "nonexistent.jsonl")])
+        assert result.exit_code == 1
+        assert "File not found" in result.output
+
+    def test_non_utf8_file(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_bytes(b"\xff\xfe invalid utf-8")
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "Cannot read file" in result.output
+
+    def test_error_output_format(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"name": "test"}\n{"url": "ftp://bad.com"}\n')
+        result = runner.invoke(app, ["validate", str(f)])
+        assert result.exit_code == 1
+        assert "Invalid:" in result.output
+        assert "2 entries" in result.output


### PR DESCRIPTION
## Summary

- Add top-level `validate` command that checks JSONL import files without requiring mcp-proxy or config file
- Extract `_collect_entry_errors` from `_resolve_import_entries` to reuse validation logic (URL scheme, name derivation, duplicates) independently of entry building
- Add `validate_ok_message` / `validate_error_message` output formatters

## Details

`cdcasasagi validate servers.jsonl` validates:
- JSONL syntax (valid JSON per line)
- Schema (required `url`, optional `name`/`transport`, no unknown keys)
- URL validity (HTTP(S) scheme, hostname present)
- Name derivation from URL
- No duplicate names or URLs within the file

Exit 0 on valid (shows resolved names and URLs), exit 1 on invalid (shows all errors). Composable with import: `cdcasasagi validate servers.jsonl && cdcasasagi import servers.jsonl --write`

## Test plan

- [x] 24 new tests (8 success cases + 16 error cases) in `TestValidate` / `TestValidateErrors`
- [x] All 163 tests pass (139 existing + 24 new)
- [x] Verified validate works without mcp-proxy installed
- [x] Verified validate works without config file
- [x] ruff format and ruff check pass

https://claude.ai/code/session_01M2Udzyt9eD6Mf4jeeU7SL3