### PR TITLE
Save stdin content to JSONL on validate-import success

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ Stdin is also supported:
 cat servers.jsonl | cdcasasagi import -
 ```
 
+### validate-import
+
+Validate a JSONL file without importing:
+
+```
+cdcasasagi validate-import servers.jsonl
+```
+
+Paste JSONL from stdin instead of preparing a file. When reading from stdin, the validated content is also saved to `./mcp-servers.jsonl` so you can hand it to `import`:
+
+```
+cdcasasagi validate-import -
+# Paste JSONL, then press Ctrl+D (Ctrl+Z on Windows)
+
+cdcasasagi import ./mcp-servers.jsonl --write
+```
+
+Use `--output` (`-o`) to save to a different path. An existing file at the target path is overwritten without prompting.
+
 ### revert
 
 Restore the config from the `.bak` backup created by the last `--write`:

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -150,8 +150,8 @@ def revert() -> None:
 # ------------------------------------------------------------------
 
 
-def _parse_import_file(file_path: str) -> tuple[list, str]:
-    """Read and parse import JSONL.  Returns ``(data, source_label)``."""
+def _parse_import_file(file_path: str) -> tuple[list, str, str]:
+    """Read and parse import JSONL.  Returns ``(data, source_label, raw_text)``."""
     if file_path == "-":
         try:
             text = sys.stdin.read()
@@ -177,7 +177,7 @@ def _parse_import_file(file_path: str) -> tuple[list, str]:
         typer.echo("Input contains no entries", err=True)
         raise typer.Exit(code=1)
 
-    return data, source_label
+    return data, source_label, text
 
 
 def _parse_jsonl(text: str, source_label: str) -> list:
@@ -309,9 +309,18 @@ def _resolve_import_entries(
 @app.command(name="validate-import")
 def validate_import(
     file: str = typer.Argument(..., help="Path to JSONL file (use - for stdin)"),
+    output_path: Path = typer.Option(
+        Path("mcp-servers.jsonl"),
+        "--output",
+        "-o",
+        help=(
+            "Path to save validated JSONL when reading from stdin "
+            "(default: ./mcp-servers.jsonl; ignored when FILE is a file path)"
+        ),
+    ),
 ) -> None:
-    """Validate a JSONL import file without importing."""
-    raw_entries, source_label = _parse_import_file(file)
+    """Validate a JSONL import file. When reading from stdin (-), save it as a JSONL file for later 'import'."""
+    raw_entries, source_label, raw_text = _parse_import_file(file)
 
     schema_errors = _validate_import_schema(raw_entries)
 
@@ -330,7 +339,20 @@ def validate_import(
         )
         raise typer.Exit(code=1)
 
-    typer.echo(output.validate_ok_message(source_label, len(raw_entries), validated))
+    saved_path: Path | None = None
+    if file == "-":
+        try:
+            output_path.write_text(raw_text, encoding="utf-8")
+        except OSError as e:
+            typer.echo(f"Cannot write output file: {output_path}\n{e}", err=True)
+            raise typer.Exit(code=1)
+        saved_path = output_path
+
+    typer.echo(
+        output.validate_ok_message(
+            source_label, len(raw_entries), validated, saved_path
+        )
+    )
 
 
 # ------------------------------------------------------------------
@@ -346,7 +368,7 @@ def import_cmd(
     verbose: bool = typer.Option(False, help="Show full diff in preview"),
 ) -> None:
     # Phase 1: Validation
-    raw_entries, source_label = _parse_import_file(file)
+    raw_entries, source_label, _ = _parse_import_file(file)
 
     try:
         proxy_path = mcp_proxy.resolve_path()

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -210,12 +210,15 @@ def validate_ok_message(
     source: str,
     entry_count: int,
     resolved: list[tuple[str, str, str]],
+    saved_path: Path | None = None,
 ) -> str:
     entry_word = "entry" if entry_count == 1 else "entries"
     lines: list[str] = [f"Valid: {source} ({entry_count} {entry_word})", ""]
     max_name = max((len(n) for n, _, _ in resolved), default=0)
     for name, url, _transport in resolved:
         lines.append(f"  {name.ljust(max_name)}  {url}")
+    if saved_path is not None:
+        lines.extend(["", f"Saved: {saved_path}"])
     return "\n".join(lines)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -609,6 +609,7 @@ class TestImportValidationErrors:
 def validate_env(tmp_path, monkeypatch):
     """Minimal env for validate — no mcp-proxy, no config file."""
     monkeypatch.setenv("CLAUDE_DESKTOP_CONFIG", str(tmp_path / "nonexistent.json"))
+    monkeypatch.chdir(tmp_path)
 
 
 class TestValidate:
@@ -674,13 +675,53 @@ class TestValidate:
         result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 0
 
-    def test_stdin(self, validate_env):
-        result = runner.invoke(
-            app, ["validate-import", "-"], input='{"url": "https://mcp.notion.com/mcp"}\n'
-        )
+    def test_stdin_saves_to_default_path(self, validate_env, tmp_path):
+        jsonl = '{"url": "https://mcp.notion.com/mcp"}\n'
+        result = runner.invoke(app, ["validate-import", "-"], input=jsonl)
         assert result.exit_code == 0
         assert "Valid:" in result.output
         assert "stdin" in result.output
+        saved = tmp_path / "mcp-servers.jsonl"
+        assert saved.exists()
+        assert saved.read_text(encoding="utf-8") == jsonl
+        assert "Saved: mcp-servers.jsonl" in result.output
+
+    def test_stdin_output_option(self, validate_env, tmp_path):
+        jsonl = '{"url": "https://mcp.notion.com/mcp"}\n'
+        dest = tmp_path / "custom.jsonl"
+        result = runner.invoke(
+            app, ["validate-import", "-", "--output", str(dest)], input=jsonl
+        )
+        assert result.exit_code == 0
+        assert dest.exists()
+        assert dest.read_text(encoding="utf-8") == jsonl
+        # Default file must NOT be created when --output is specified.
+        assert not (tmp_path / "mcp-servers.jsonl").exists()
+
+    def test_stdin_overwrites_existing_file(self, validate_env, tmp_path):
+        existing = tmp_path / "mcp-servers.jsonl"
+        existing.write_text("old content\n", encoding="utf-8")
+        jsonl = '{"url": "https://mcp.notion.com/mcp"}\n'
+        result = runner.invoke(app, ["validate-import", "-"], input=jsonl)
+        assert result.exit_code == 0
+        assert existing.read_text(encoding="utf-8") == jsonl
+
+    def test_stdin_short_output_flag(self, validate_env, tmp_path):
+        jsonl = '{"url": "https://mcp.notion.com/mcp"}\n'
+        dest = tmp_path / "short.jsonl"
+        result = runner.invoke(
+            app, ["validate-import", "-", "-o", str(dest)], input=jsonl
+        )
+        assert result.exit_code == 0
+        assert dest.read_text(encoding="utf-8") == jsonl
+
+    def test_file_input_does_not_save(self, validate_env, tmp_path):
+        f = tmp_path / "servers.jsonl"
+        f.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
+        result = runner.invoke(app, ["validate-import", str(f)])
+        assert result.exit_code == 0
+        assert not (tmp_path / "mcp-servers.jsonl").exists()
+        assert "Saved:" not in result.output
 
 
 class TestValidateErrors:
@@ -785,7 +826,9 @@ class TestValidateErrors:
         assert "Duplicate url" in result.output
 
     def test_file_not_found(self, validate_env, tmp_path):
-        result = runner.invoke(app, ["validate-import", str(tmp_path / "nonexistent.jsonl")])
+        result = runner.invoke(
+            app, ["validate-import", str(tmp_path / "nonexistent.jsonl")]
+        )
         assert result.exit_code == 1
         assert "File not found" in result.output
 
@@ -803,3 +846,11 @@ class TestValidateErrors:
         assert result.exit_code == 1
         assert "Invalid:" in result.output
         assert "2 entries" in result.output
+
+    def test_stdin_validation_error_does_not_save(self, validate_env, tmp_path):
+        # Schema error: missing required url key.
+        result = runner.invoke(
+            app, ["validate-import", "-"], input='{"name": "test"}\n'
+        )
+        assert result.exit_code == 1
+        assert not (tmp_path / "mcp-servers.jsonl").exists()


### PR DESCRIPTION
## Summary

- `cdcasasagi validate-import -` reads stdin, validates, and now also writes the raw input to `./mcp-servers.jsonl` when validation passes. The saved file is ready to hand to `cdcasasagi import` in a follow-up call.
- Added `--output` / `-o` to customize the destination path. The target is overwritten unconditionally. File-path input mode is unchanged (no save).
- First step toward the paste-from-clipboard flow envisioned in the issue description: paste JSONL, validate, then `import` the resulting file.

## Why

cdcasasagi is aiming for a "paste JSONL from the clipboard" UX. Instead of introducing a separate `--stdin` option, this patch extends the existing stdin path (`-`) to persist the input so the later `import` step can consume it without hand-rolled file management.

## Changes

- `src/cdcasasagi/cli.py` — `_parse_import_file` now also returns the raw text; `validate_import` writes it to `--output` (default `./mcp-servers.jsonl`) when FILE is `-`.
- `src/cdcasasagi/output.py` — `validate_ok_message` accepts an optional `saved_path` and appends a `Saved:` line.
- `tests/test_cli.py` — new tests covering default-path save, `--output` override, unconditional overwrite, file-input does-not-save, and validation-error does-not-save. Existing `test_stdin` replaced to pin the chdir (prevents touching the repo).
- `README.md` — documents the new behavior under a `validate-import` section.

## Test plan

- [x] `uv run ruff format src/ tests/`
- [x] `uv run ruff check --fix src/ tests/`
- [x] `uv run pytest` (168 passed)
- [x] Manual: `printf '{"url": "https://mcp.notion.com/mcp"}\n' | cdcasasagi validate-import -` creates `./mcp-servers.jsonl`
- [x] Manual: `... | cdcasasagi validate-import - --output /tmp/custom.jsonl` writes to the given path
- [x] Manual: file-input `cdcasasagi validate-import some.jsonl` does not create `./mcp-servers.jsonl`
- [x] Manual: invalid stdin (`{"name": "x"}`) fails without creating a file

https://claude.ai/code/session_01SMWNiCZoQd4Z2P4WBHxaKg