### PR TITLE
Enter to end stdin input when pasting interactively

### DIFF
--- a/.github/workflows/e2e_v2.yml
+++ b/.github/workflows/e2e_v2.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Install Gauge CLI and plugins
       uses: getgauge/setup-gauge@50709cf75e99bb852890c8826b9600a237981ff1 # master
       with:
+        gauge-version: v1.6.28
         gauge-plugins: python, html-report
     - name: Install dependencies
       run: uv sync --group dev

--- a/.github/workflows/e2e_v2.yml
+++ b/.github/workflows/e2e_v2.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install Gauge CLI and plugins
       uses: getgauge/setup-gauge@50709cf75e99bb852890c8826b9600a237981ff1 # master
       with:
-        gauge-version: v1.6.28
+        gauge-version: '1.6.28'
         gauge-plugins: python, html-report
     - name: Install dependencies
       run: uv sync --group dev

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Paste JSONL from stdin instead of preparing a file. When reading from stdin, the
 
 ```
 cdcasasagi validate-import -
-# Paste JSONL, then press Ctrl+D (Ctrl+Z on Windows)
+# Paste JSONL, then press Enter on a blank line to finish
+# (Ctrl+D / Ctrl+Z also works)
 
 cdcasasagi import ./mcp-servers.jsonl --write
 ```

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -160,9 +160,11 @@ def _read_stdin_jsonl() -> str:
     if not sys.stdin.isatty():
         return sys.stdin.read()
 
-    typer.echo(
-        "Paste JSONL, then press Enter on a blank line to finish (or Ctrl+D / Ctrl+Z):",
+    typer.secho(
+        "Paste JSONL, then press Enter on a blank line to finish "
+        "(or Ctrl+D on macOS / Ctrl+Z on Windows):",
         err=True,
+        fg=typer.colors.CYAN,
     )
     lines: list[str] = []
     for line in sys.stdin:

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -150,11 +150,33 @@ def revert() -> None:
 # ------------------------------------------------------------------
 
 
+def _read_stdin_jsonl() -> str:
+    """Read JSONL from stdin.
+
+    When stdin is a TTY (interactive paste), stop at the first blank line so
+    a single extra Enter after paste finishes input. Otherwise (piped), read
+    to EOF as usual.
+    """
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+
+    typer.echo(
+        "Paste JSONL, then press Enter on a blank line to finish (or Ctrl+D / Ctrl+Z):",
+        err=True,
+    )
+    lines: list[str] = []
+    for line in sys.stdin:
+        if line.strip() == "":
+            break
+        lines.append(line)
+    return "".join(lines)
+
+
 def _parse_import_file(file_path: str) -> tuple[list, str, str]:
     """Read and parse import JSONL.  Returns ``(data, source_label, raw_text)``."""
     if file_path == "-":
         try:
-            text = sys.stdin.read()
+            text = _read_stdin_jsonl()
         except UnicodeDecodeError as e:
             typer.echo(f"Cannot read stdin: {e}", err=True)
             raise typer.Exit(code=1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -723,6 +723,47 @@ class TestValidate:
         assert not (tmp_path / "mcp-servers.jsonl").exists()
         assert "Saved:" not in result.output
 
+    def test_tty_stdin_blank_line_terminates(self, monkeypatch):
+        """TTY stdin stops reading at the first blank line."""
+        import io
+
+        from cdcasasagi.cli import _read_stdin_jsonl
+
+        class FakeStdin(io.StringIO):
+            def isatty(self):
+                return True
+
+        text = (
+            '{"url": "https://mcp.notion.com/mcp"}\n'
+            '{"url": "https://mcp.linear.app/mcp"}\n'
+            "\n"
+            # Anything after the blank line must be ignored.
+            '{"url": "https://ignored.example.com/mcp"}\n'
+        )
+        monkeypatch.setattr("cdcasasagi.cli.sys.stdin", FakeStdin(text))
+        assert _read_stdin_jsonl() == (
+            '{"url": "https://mcp.notion.com/mcp"}\n'
+            '{"url": "https://mcp.linear.app/mcp"}\n'
+        )
+
+    def test_piped_stdin_reads_to_eof(self, monkeypatch):
+        """Non-TTY stdin reads all the way to EOF (blank lines don't stop it)."""
+        import io
+
+        from cdcasasagi.cli import _read_stdin_jsonl
+
+        class FakeStdin(io.StringIO):
+            def isatty(self):
+                return False
+
+        text = (
+            '{"url": "https://a.example.com/mcp"}\n'
+            "\n"
+            '{"url": "https://b.example.com/mcp"}\n'
+        )
+        monkeypatch.setattr("cdcasasagi.cli.sys.stdin", FakeStdin(text))
+        assert _read_stdin_jsonl() == text
+
 
 class TestValidateErrors:
     def test_invalid_jsonl(self, validate_env, tmp_path):


### PR DESCRIPTION
## Summary

- Adds blank-line termination for `validate-import -` / `import -` when stdin is a TTY. After pasting JSONL, pressing Enter on a blank line finishes input — no more hunting for Ctrl+D / Ctrl+Z.
- Piped stdin (`cat file.jsonl | cdcasasagi ...`) is unchanged: reads to real EOF, so blank lines between entries are still harmless.
- Ctrl+D / Ctrl+Z continues to work as before.

Implementation is a few lines in `_read_stdin_jsonl`: when `sys.stdin.isatty()` is true, read line by line and stop at the first empty line; otherwise use `sys.stdin.read()` as before. No new dependencies.

Closes the need discussed in conversation — chose this over introducing a clipboard dependency (e.g. `pyperclip`) to keep the footprint minimal.

## Test plan

- [x] `uv run pytest` — 170 passed
- [x] `uv run ruff check --fix src/ tests/`
- [x] `uv run ruff format src/ tests/`
- [x] Manual: run `cdcasasagi validate-import -` in a terminal, paste JSONL, press Enter on a blank line, confirm it validates and saves to `./mcp-servers.jsonl`
- [x] Manual: confirm `cat servers.jsonl | cdcasasagi validate-import -` still works end-to-end