### PR TITLE
Honor NO_COLOR env var in interactive stdin prompt

### DIFF
--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -160,11 +160,12 @@ def _read_stdin_jsonl() -> str:
     if not sys.stdin.isatty():
         return sys.stdin.read()
 
+    fg = None if os.environ.get("NO_COLOR") else typer.colors.CYAN
     typer.secho(
         "Paste JSONL, then press Enter on a blank line to finish "
         "(or Ctrl+D on macOS / Ctrl+Z on Windows):",
         err=True,
-        fg=typer.colors.CYAN,
+        fg=fg,
     )
     lines: list[str] = []
     for line in sys.stdin:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import os
 from importlib.metadata import version as pkg_version
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from cdcasasagi.cli import app
@@ -763,6 +764,46 @@ class TestValidate:
         )
         monkeypatch.setattr("cdcasasagi.cli.sys.stdin", FakeStdin(text))
         assert _read_stdin_jsonl() == text
+
+    def test_no_color_env_strips_ansi_from_prompt(self, monkeypatch, capsys):
+        """NO_COLOR=<non-empty> must suppress ANSI escape codes in the prompt."""
+        import io
+
+        from cdcasasagi.cli import _read_stdin_jsonl
+
+        class FakeStdin(io.StringIO):
+            def isatty(self):
+                return True
+
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr("cdcasasagi.cli.sys.stdin", FakeStdin(""))
+        _read_stdin_jsonl()
+        captured = capsys.readouterr()
+        assert "\x1b[" not in captured.err
+        assert "Paste JSONL" in captured.err
+
+    def test_no_color_empty_string_keeps_color_path(self, monkeypatch):
+        """NO_COLOR="" (empty) is treated as unset per the no-color.org spec."""
+        import io
+
+        from cdcasasagi.cli import _read_stdin_jsonl
+
+        class FakeStdin(io.StringIO):
+            def isatty(self):
+                return True
+
+        captured_fg: list = []
+        original_secho = typer.secho
+
+        def fake_secho(*args, **kwargs):
+            captured_fg.append(kwargs.get("fg"))
+            return original_secho(*args, **kwargs)
+
+        monkeypatch.setenv("NO_COLOR", "")
+        monkeypatch.setattr("cdcasasagi.cli.typer.secho", fake_secho)
+        monkeypatch.setattr("cdcasasagi.cli.sys.stdin", FakeStdin(""))
+        _read_stdin_jsonl()
+        assert captured_fg == [typer.colors.CYAN]
 
 
 class TestValidateErrors:


### PR DESCRIPTION
## Summary

PR #17 で追加したシアンの `typer.secho` プロンプトに `NO_COLOR` 環境変数対応を追加します (https://no-color.org/)。

Typer (Click) は `NO_COLOR` を自動では尊重しない (Click 8.3.2 で確認) ので、`_read_stdin_jsonl` 内で明示的に `fg` を解決します:

```python
fg = None if os.environ.get("NO_COLOR") else typer.colors.CYAN
typer.secho(..., err=True, fg=fg)
```

仕様通り、`NO_COLOR` が **存在しかつ空でない** ときのみ色を抑止します (`NO_COLOR=""` はセットされていない扱い)。

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` — 172 passed
- [x] 新規テスト: `NO_COLOR=1` のとき stderr に ANSI エスケープが含まれない
- [x] 新規テスト: `NO_COLOR=""` (空文字) は未設定扱いでシアンのまま