### PR TITLE
e2e: Split step_impl.py into per-concern modules

### DIFF
--- a/e2e/step_impl/steps_add.py
+++ b/e2e/step_impl/steps_add.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from getgauge.python import data_store, step
+
+
+@step("プレビューが表示される")
+def assert_preview_shown():
+    result = data_store.scenario["last_result"]
+    assert result.returncode == 0, (
+        f"exit code {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "This is a preview" in result.stdout, (
+        f"preview marker not found in stdout:\n{result.stdout}"
+    )

--- a/e2e/step_impl/steps_common.py
+++ b/e2e/step_impl/steps_common.py
@@ -50,17 +50,6 @@ def run_cdcasasagi(args):
     data_store.scenario["last_result"] = result
 
 
-@step("プレビューが表示される")
-def assert_preview_shown():
-    result = data_store.scenario["last_result"]
-    assert result.returncode == 0, (
-        f"exit code {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
-    assert "This is a preview" in result.stdout, (
-        f"preview marker not found in stdout:\n{result.stdout}"
-    )
-
-
 @step("設定ファイルは変更されていない")
 def assert_config_unchanged():
     initial = data_store.scenario["initial_config"]


### PR DESCRIPTION
## Summary
- Move shared Given/Then steps (guard, CLI runner, initial config setup, config-unchanged assertion) to `e2e/step_impl/steps_common.py`
- Move the `add`-specific preview assertion to `e2e/step_impl/steps_add.py`
- Delete the monolithic `e2e/step_impl/step_impl.py`

This unblocks follow-up E2E specs (`add --write`, `import`, `validate-import`, `revert`, error paths) from colliding on a single step file. Per-concern modules for `import` / `revert` will be created by their own follow-up issues when they first have content.

Closes #20

## Test plan
- [x] `gauge run specs/` passes (`add.spec` still green)
- [x] `ruff format` / `ruff check --fix` clean
- [x] `pytest` (170 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)