### PR TITLE
e2e: Add --write round-trip scenarios

### DIFF
--- a/e2e/specs/add_write.spec
+++ b/e2e/specs/add_write.spec
@@ -1,0 +1,55 @@
+# cdcasasagi add --write
+
+`--write` の round-trip (設定ファイル書き込み / .bak 作成 / revert) のE2E
+
+## add --write は設定ファイルと .bak を作成する
+
+* MCPサーバ設定なしでClaude Desktopが使われている
+* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
+* 設定ファイルに"notion"エントリが書き込まれている
+* バックアップファイルが作成されている
+
+## 2回目の --write は直前の状態を .bak に残す
+
+* MCPサーバ設定なしでClaude Desktopが使われている
+* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
+* 設定ファイルに"notion"エントリが書き込まれている
+* cdcasasagiで"add https://developers.openai.com/mcp --write"を実行する
+* 設定ファイルに"notion,developers"エントリが書き込まれている
+* バックアップファイルに"notion"エントリが書き込まれている
+
+## 既存エントリとの衝突は --force なしで失敗する
+
+* MCPサーバ設定なしでClaude Desktopが使われている
+* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
+* 設定ファイルに"notion"エントリが書き込まれている
+* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
+* 直前のコマンドは失敗する
+* 設定ファイルは直前の書き込みから変更されていない
+
+## 同一URLを別名で --write すると失敗する
+
+* MCPサーバ設定なしでClaude Desktopが使われている
+* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
+* 設定ファイルに"notion"エントリが書き込まれている
+* cdcasasagiで"add https://mcp.notion.com/mcp --name my-notion --write"を実行する
+* 直前のコマンドは失敗する
+* 設定ファイルは直前の書き込みから変更されていない
+
+## --force を付けると別名にリネームされる
+
+* MCPサーバ設定なしでClaude Desktopが使われている
+* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
+* 設定ファイルに"notion"エントリが書き込まれている
+* cdcasasagiで"add https://mcp.notion.com/mcp --name my-notion --write --force"を実行する
+* 設定ファイルに"my-notion"エントリが書き込まれている
+* 設定ファイル内"my-notion"のURLは"https://mcp.notion.com/mcp"である
+
+## revert はバックアップファイルの状態に戻す
+
+* MCPサーバ設定なしでClaude Desktopが使われている
+* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
+* cdcasasagiで"add https://developers.openai.com/mcp --write"を実行する
+* 設定ファイルに"notion,developers"エントリが書き込まれている
+* cdcasasagiで"revert"を実行する
+* 設定ファイルに"notion"エントリが書き込まれている

--- a/e2e/step_impl/steps_add_write.py
+++ b/e2e/step_impl/steps_add_write.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+
+from getgauge.python import data_store, step
+
+from cdcasasagi.desktop_config import backup_path, config_path
+
+
+def _parse_names(names: str) -> set[str]:
+    return {n.strip() for n in names.split(",") if n.strip()}
+
+
+def _load_json(path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@step("設定ファイルに<names>エントリが書き込まれている")
+def assert_config_has_entries(names):
+    path = config_path()
+    config = _load_json(path)
+    actual = set(config.get("mcpServers", {}).keys())
+    expected = _parse_names(names)
+    assert actual == expected, f"expected entries {expected}, got {actual}"
+    data_store.scenario["last_written_config"] = path.read_bytes()
+
+
+@step("バックアップファイルが作成されている")
+def assert_backup_exists():
+    bak = backup_path(config_path())
+    assert bak.exists(), f"backup file not found: {bak}"
+
+
+@step("バックアップファイルに<names>エントリが書き込まれている")
+def assert_backup_has_entries(names):
+    bak = backup_path(config_path())
+    assert bak.exists(), f"backup file not found: {bak}"
+    config = _load_json(bak)
+    actual = set(config.get("mcpServers", {}).keys())
+    expected = _parse_names(names)
+    assert actual == expected, f"expected backup entries {expected}, got {actual}"
+
+
+@step("直前のコマンドは失敗する")
+def assert_last_command_failed():
+    result = data_store.scenario["last_result"]
+    assert result.returncode != 0, (
+        f"expected non-zero exit, got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+@step("設定ファイルは直前の書き込みから変更されていない")
+def assert_config_unchanged_since_last_write():
+    snapshot = data_store.scenario["last_written_config"]
+    current = config_path().read_bytes()
+    assert current == snapshot, (
+        f"config changed since last write.\nexpected:\n{snapshot!r}\nactual:\n{current!r}"
+    )
+
+
+@step("設定ファイル内<name>のURLは<url>である")
+def assert_entry_url(name, url):
+    config = _load_json(config_path())
+    entry = config.get("mcpServers", {}).get(name)
+    assert entry is not None, f'entry "{name}" not found in config'
+    args = entry.get("args", [])
+    assert args and args[-1] == url, (
+        f'expected URL {url!r} at end of args for "{name}", got args={args!r}'
+    )


### PR DESCRIPTION
Closes #22

## Summary
- Add `e2e/specs/add_write.spec` with 6 scenarios covering the `--write` path: config + .bak creation, second-write .bak retention, `--force`-less conflict failure, same-URL different-name failure, `--force` rename, and `revert` restoring from .bak.
- Add `e2e/step_impl/steps_add_write.py` with step implementations that parse JSON (no string matching).

## Test plan
- [x] `uv run --no-sync gauge run specs/add_write.spec` — 6/6 pass
- [x] `uv run --no-sync pytest` — 170 pass
- [x] `uv run --no-sync ruff check e2e/ src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)