### PR TITLE
e2e: Translate specs and step_impl to English

### DIFF
--- a/e2e/specs/add.spec
+++ b/e2e/specs/add.spec
@@ -1,10 +1,10 @@
 # cdcasasagi add
 
-MCPサーバをClaude Desktopの設定に追加する `cdcasasagi add` のE2E
+E2E for `cdcasasagi add`, which adds an MCP server entry to the Claude Desktop config
 
-## プレビューが表示される
+## A preview is shown
 
-* MCPサーバ設定なしでClaude Desktopが使われている
-* cdcasasagiで"add https://mcp.notion.com/mcp"を実行する
-* プレビューが表示される
-* 設定ファイルは変更されていない
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp"
+* A preview is shown
+* The config file is unchanged

--- a/e2e/specs/add_write.spec
+++ b/e2e/specs/add_write.spec
@@ -1,55 +1,55 @@
 # cdcasasagi add --write
 
-`--write` の round-trip (設定ファイル書き込み / .bak 作成 / revert) のE2E
+E2E for the `--write` round-trip (write the config file / create .bak / revert from .bak)
 
-## add --write は設定ファイルと .bak を作成する
+## add --write creates the config file and .bak
 
-* MCPサーバ設定なしでClaude Desktopが使われている
-* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
-* 設定ファイルに"notion"エントリが書き込まれている
-* バックアップファイルが作成されている
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* "notion" entry is written to the config file
+* The backup file is created
 
-## 2回目の --write は直前の状態を .bak に残す
+## The second --write preserves the previous state in .bak
 
-* MCPサーバ設定なしでClaude Desktopが使われている
-* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
-* 設定ファイルに"notion"エントリが書き込まれている
-* cdcasasagiで"add https://developers.openai.com/mcp --write"を実行する
-* 設定ファイルに"notion,developers"エントリが書き込まれている
-* バックアップファイルに"notion"エントリが書き込まれている
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* "notion" entry is written to the config file
+* Run cdcasasagi "add https://developers.openai.com/mcp --write"
+* "notion,developers" entries are written to the config file
+* "notion" entry is written to the backup file
 
-## 既存エントリとの衝突は --force なしで失敗する
+## add --write fails on a conflict without --force
 
-* MCPサーバ設定なしでClaude Desktopが使われている
-* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
-* 設定ファイルに"notion"エントリが書き込まれている
-* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
-* 直前のコマンドは失敗する
-* 設定ファイルは直前の書き込みから変更されていない
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* "notion" entry is written to the config file
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* The last command fails
+* The config file is unchanged since the last write
 
-## 同一URLを別名で --write すると失敗する
+## --write with a different name for the same URL fails
 
-* MCPサーバ設定なしでClaude Desktopが使われている
-* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
-* 設定ファイルに"notion"エントリが書き込まれている
-* cdcasasagiで"add https://mcp.notion.com/mcp --name my-notion --write"を実行する
-* 直前のコマンドは失敗する
-* 設定ファイルは直前の書き込みから変更されていない
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* "notion" entry is written to the config file
+* Run cdcasasagi "add https://mcp.notion.com/mcp --name my-notion --write"
+* The last command fails
+* The config file is unchanged since the last write
 
-## --force を付けると別名にリネームされる
+## With --force the entry is renamed
 
-* MCPサーバ設定なしでClaude Desktopが使われている
-* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
-* 設定ファイルに"notion"エントリが書き込まれている
-* cdcasasagiで"add https://mcp.notion.com/mcp --name my-notion --write --force"を実行する
-* 設定ファイルに"my-notion"エントリが書き込まれている
-* 設定ファイル内"my-notion"のURLは"https://mcp.notion.com/mcp"である
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* "notion" entry is written to the config file
+* Run cdcasasagi "add https://mcp.notion.com/mcp --name my-notion --write --force"
+* "my-notion" entry is written to the config file
+* The URL of "my-notion" in the config file is "https://mcp.notion.com/mcp"
 
-## revert はバックアップファイルの状態に戻す
+## revert restores the state from the backup file
 
-* MCPサーバ設定なしでClaude Desktopが使われている
-* cdcasasagiで"add https://mcp.notion.com/mcp --write"を実行する
-* cdcasasagiで"add https://developers.openai.com/mcp --write"を実行する
-* 設定ファイルに"notion,developers"エントリが書き込まれている
-* cdcasasagiで"revert"を実行する
-* 設定ファイルに"notion"エントリが書き込まれている
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* Run cdcasasagi "add https://developers.openai.com/mcp --write"
+* "notion,developers" entries are written to the config file
+* Run cdcasasagi "revert"
+* "notion" entry is written to the config file

--- a/e2e/step_impl/steps_add.py
+++ b/e2e/step_impl/steps_add.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from getgauge.python import data_store, step
 
 
-@step("プレビューが表示される")
+@step("A preview is shown")
 def assert_preview_shown():
     result = data_store.scenario["last_result"]
     assert result.returncode == 0, (

--- a/e2e/step_impl/steps_add_write.py
+++ b/e2e/step_impl/steps_add_write.py
@@ -15,7 +15,12 @@ def _load_json(path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-@step("設定ファイルに<names>エントリが書き込まれている")
+@step(
+    [
+        "<names> entry is written to the config file",
+        "<names> entries are written to the config file",
+    ]
+)
 def assert_config_has_entries(names):
     path = config_path()
     config = _load_json(path)
@@ -25,13 +30,18 @@ def assert_config_has_entries(names):
     data_store.scenario["last_written_config"] = path.read_bytes()
 
 
-@step("バックアップファイルが作成されている")
+@step("The backup file is created")
 def assert_backup_exists():
     bak = backup_path(config_path())
     assert bak.exists(), f"backup file not found: {bak}"
 
 
-@step("バックアップファイルに<names>エントリが書き込まれている")
+@step(
+    [
+        "<names> entry is written to the backup file",
+        "<names> entries are written to the backup file",
+    ]
+)
 def assert_backup_has_entries(names):
     bak = backup_path(config_path())
     assert bak.exists(), f"backup file not found: {bak}"
@@ -41,7 +51,7 @@ def assert_backup_has_entries(names):
     assert actual == expected, f"expected backup entries {expected}, got {actual}"
 
 
-@step("直前のコマンドは失敗する")
+@step("The last command fails")
 def assert_last_command_failed():
     result = data_store.scenario["last_result"]
     assert result.returncode != 0, (
@@ -50,7 +60,7 @@ def assert_last_command_failed():
     )
 
 
-@step("設定ファイルは直前の書き込みから変更されていない")
+@step("The config file is unchanged since the last write")
 def assert_config_unchanged_since_last_write():
     snapshot = data_store.scenario["last_written_config"]
     current = config_path().read_bytes()
@@ -59,7 +69,7 @@ def assert_config_unchanged_since_last_write():
     )
 
 
-@step("設定ファイル内<name>のURLは<url>である")
+@step("The URL of <name> in the config file is <url>")
 def assert_entry_url(name, url):
     config = _load_json(config_path())
     entry = config.get("mcpServers", {}).get(name)

--- a/e2e/step_impl/steps_common.py
+++ b/e2e/step_impl/steps_common.py
@@ -31,7 +31,7 @@ def _guard_against_overwriting_real_config():
     )
 
 
-@step("MCPサーバ設定なしでClaude Desktopが使われている")
+@step("Claude Desktop is used with no MCP server entries")
 def given_claude_desktop_without_mcp_servers():
     _guard_against_overwriting_real_config()
     path = config_path()
@@ -40,7 +40,7 @@ def given_claude_desktop_without_mcp_servers():
     data_store.scenario["initial_config"] = _INITIAL_CONFIG
 
 
-@step("cdcasasagiで<args>を実行する")
+@step("Run cdcasasagi <args>")
 def run_cdcasasagi(args):
     # Invoke the CLI via the same interpreter that imported cdcasasagi above,
     # so the E2E always exercises the code in this checkout (not whatever
@@ -50,7 +50,7 @@ def run_cdcasasagi(args):
     data_store.scenario["last_result"] = result
 
 
-@step("設定ファイルは変更されていない")
+@step("The config file is unchanged")
 def assert_config_unchanged():
     initial = data_store.scenario["initial_config"]
     current = config_path().read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Translated `e2e/specs/add.spec` and `e2e/specs/add_write.spec` from Japanese to English
- Updated `@step` decorators in `steps_common.py`, `steps_add.py`, `steps_add_write.py` to match
- Used gauge-python's list form `@step([...])` to accept both singular ("entry is written") and plural ("entries are written") variants

## Test plan
- [x] `uv run --no-sync gauge run specs` — 2 specs / 7 scenarios pass
- [x] `ruff format` / `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)