### PR TITLE
e2e: Add error surfacing scenarios

### DIFF
--- a/e2e/specs/errors.spec
+++ b/e2e/specs/errors.spec
@@ -1,0 +1,32 @@
+# cdcasasagi error surfacing
+
+E2E for errors surfacing through the subprocess boundary: non-zero exit code,
+expected stderr, and no config mutation on the error path.
+
+## add rejects an invalid URL and leaves the config file unchanged
+
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add not-a-url --write"
+* The last command fails
+* stderr contains "Please specify a valid HTTP(S) URL"
+* The config file is unchanged
+
+## revert fails when the backup file does not exist
+
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "revert"
+* The last command fails
+* stderr contains "Backup not found"
+* The config file is unchanged
+
+## Broken JSONL writes nothing even with import --write
+
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "import - --write" with stdin <stdin>
+   """
+   {"url": "https://mcp.notion.com/mcp"}
+   {not json}
+   """
+* The last command fails
+* stderr contains "Failed to parse JSON Lines"
+* The config file is unchanged

--- a/e2e/step_impl/steps_errors.py
+++ b/e2e/step_impl/steps_errors.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+
+from getgauge.python import data_store, step
+
+
+@step("Run cdcasasagi <args> with stdin <stdin>")
+def run_cdcasasagi_with_stdin(args, stdin):
+    cmd = [sys.executable, "-m", "cdcasasagi"] + shlex.split(args)
+    result = subprocess.run(cmd, input=stdin, capture_output=True, text=True)
+    data_store.scenario["last_result"] = result
+
+
+@step("stderr contains <text>")
+def assert_stderr_contains(text):
+    result = data_store.scenario["last_result"]
+    assert text in result.stderr, (
+        f"stderr does not contain {text!r}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
Closes #24.

## Summary

Adds `e2e/specs/errors.spec` covering the three error paths called out in the issue:

- `add` rejects an invalid URL (`--write` does not mutate the config)
- `revert` fails when no `.bak` exists
- `import - --write` writes nothing when the JSONL is malformed

Each scenario asserts non-zero exit, an expected stderr substring, and that the config file is unchanged.

New step impls live in `e2e/step_impl/steps_errors.py`:

- `Run cdcasasagi <args> with stdin <stdin>` — runs the CLI with a multi-line text block piped to stdin (used for the broken-JSONL case).
- `stderr contains <text>` — substring assertion against the captured stderr.

The third scenario uses Gauge's multi-line text block as the value for `<stdin>`, so the JSONL fixture is inline in the spec rather than a separate file.

## Test plan

- [x] `e2e_v2` workflow on macOS and Windows runs the new spec to green
- [x] Existing `gauge run specs` still passes (other specs unaffected)
- [x] `uv run --no-sync pytest` passes locally (172/172)
- [x] `uv run --no-sync ruff check` and `ruff format` clean