### PR TITLE
e2e: Add non-developer handoff journey spec

### DIFF
--- a/e2e/specs/handoff.spec
+++ b/e2e/specs/handoff.spec
@@ -1,0 +1,22 @@
+# cdcasasagi handoff (validate-import - -> import --write -> revert)
+
+tags: handoff
+
+E2E for the non-developer handoff journey described in `docs/author-workflow.md`:
+paste JSONL into `validate-import -`, run `import --write`, and `revert` as the
+escape hatch.
+
+## Paste JSONL, import --write, then revert back to the empty initial state
+
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "validate-import -" with the following JSONL piped to stdin
+     |url                                |name                 |
+     |-----------------------------------|---------------------|
+     |https://developers.openai.com/mcp  |openai-developer-docs|
+     |https://mcp.notion.com/mcp         |                     |
+* The staging file "mcp-servers.jsonl" is created
+* Run cdcasasagi "import ./mcp-servers.jsonl --write"
+* "openai-developer-docs,notion" entries are written to the config file
+* The backup file is created
+* Run cdcasasagi "revert"
+* The config file has no MCP server entries

--- a/e2e/step_impl/steps_handoff.py
+++ b/e2e/step_impl/steps_handoff.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+from getgauge.python import after_scenario, data_store, step
+
+from cdcasasagi.desktop_config import config_path
+
+_JSONL_KEYS = ("url", "name", "transport")
+
+
+def _row_to_entry(headers: list[str], row: list[str]) -> dict[str, str]:
+    entry: dict[str, str] = {}
+    for header, value in zip(headers, row):
+        if header in _JSONL_KEYS and value:
+            entry[header] = value
+    return entry
+
+
+@step("Run cdcasasagi <args> with the following JSONL piped to stdin <table>")
+def run_cdcasasagi_with_jsonl(args, table):
+    lines = [json.dumps(_row_to_entry(table.headers, row)) for row in table.rows]
+    stdin_input = "\n".join(lines) + "\n"
+    cmd = [sys.executable, "-m", "cdcasasagi"] + shlex.split(args)
+    result = subprocess.run(cmd, input=stdin_input, capture_output=True, text=True)
+    data_store.scenario["last_result"] = result
+    data_store.scenario["staging_jsonl_cleanup"] = True
+
+
+@step('The staging file "<path>" is created')
+def assert_staging_file_created(path):
+    staged = Path(path)
+    assert staged.is_file(), f"staging file not created: {staged.resolve()}"
+
+
+@step("The config file has no MCP server entries")
+def assert_config_has_no_entries():
+    config = json.loads(config_path().read_text(encoding="utf-8"))
+    servers = config.get("mcpServers", {})
+    assert servers == {}, f"expected no mcpServers entries, got {servers}"
+
+
+@after_scenario("<handoff>")
+def cleanup_staging_jsonl():
+    if not data_store.scenario.get("staging_jsonl_cleanup"):
+        return
+    staged = Path("mcp-servers.jsonl")
+    if staged.is_file():
+        staged.unlink()


### PR DESCRIPTION
Closes #21

## Summary
- Add `e2e/specs/handoff.spec` covering the paste-and-done journey described in `docs/author-workflow.md`: pipe JSONL into `validate-import -`, confirm `./mcp-servers.jsonl` is staged, run `import ./mcp-servers.jsonl --write`, and finally `revert` back to the empty initial state.
- Add `e2e/step_impl/steps_handoff.py` with:
  - `Run cdcasasagi <args> with the following JSONL piped to stdin <table>` — pipes stdin via `subprocess.run(..., input=...)` so `_read_stdin_jsonl` hits the non-TTY branch.
  - `The staging file "<path>" is created` — checks the predictable path `validate-import -` writes to.
  - `The config file has no MCP server entries` — parses the JSON and asserts `mcpServers == {}`.
  - `@after_scenario("<handoff>")` — removes `./mcp-servers.jsonl` so the spec leaves no trace in the gauge cwd.
- Reuses existing steps for `Claude Desktop is used with no MCP server entries`, `<names> entries are written to the config file`, and `The backup file is created`.

## Test plan
- [x] `uv run --no-sync ruff format e2e/ src/ tests/` — clean
- [x] `uv run --no-sync ruff check --fix e2e/ src/ tests/` — clean
- [x] `uv run --no-sync pytest` — 172 passed
- [x] Manually executed the `validate-import -` + `import --write` + `revert` sequence against a throwaway `CLAUDE_DESKTOP_CONFIG` to confirm the end state is `{}` (no `mcpServers`).
- [x] Gauge CLI not available in this sandbox — rely on the E2E v2 workflow (macOS / Windows) to confirm the new spec passes.