### PR TITLE
e2e: Add Gauge spec for import --write preview and merge

### DIFF
--- a/e2e/specs/import_write.spec
+++ b/e2e/specs/import_write.spec
@@ -1,0 +1,35 @@
+# cdcasasagi import --write
+
+E2E for `cdcasasagi import` covering the non-conflict `--write` round-trip:
+preview is non-destructive, the first `--write` writes every entry, and a
+second `--write` merges new entries with existing ones while saving the
+previous state to `.bak`.
+
+## A preview is shown
+
+* Claude Desktop is used with no MCP server entries
+* Pipe JSONL to cdcasasagi "import -"
+
+   |url                          |
+   |-----------------------------|
+   |https://mcp.notion.com/mcp   |
+   |https://mcp.linear.app/mcp   |
+* The config file is unchanged
+
+## The second --write merges new entries and preserves the previous state in .bak
+
+* Claude Desktop is used with no MCP server entries
+* Pipe JSONL to cdcasasagi "import - --write"
+
+   |url                          |
+   |-----------------------------|
+   |https://mcp.notion.com/mcp   |
+   |https://mcp.linear.app/mcp   |
+* "notion,linear" entries are written to the config file
+* Pipe JSONL to cdcasasagi "import - --write"
+
+   |url                          |
+   |-----------------------------|
+   |https://huggingface.co/mcp   |
+* "notion,linear,huggingface" entries are written to the config file
+* "notion,linear" entries are written to the backup file

--- a/e2e/specs/import_write.spec
+++ b/e2e/specs/import_write.spec
@@ -14,6 +14,7 @@ previous state to `.bak`.
    |-----------------------------|
    |https://mcp.notion.com/mcp   |
    |https://mcp.linear.app/mcp   |
+* A preview is shown
 * The config file is unchanged
 
 ## The second --write merges new entries and preserves the previous state in .bak


### PR DESCRIPTION
## Summary
- Add `e2e/specs/import_write.spec` covering two `import` scenarios that previously existed only in the shell-script E2E (`.github/workflows/e2e.yml`):
  - `import` preview (no `--write`) does not modify the config file.
  - A second `import --write` merges new entries with existing ones and preserves the previous state in `.bak`.
- All required step implementations already exist in `steps_common.py`, `steps_add_write.py`, and `steps_import_conflict.py`, so no new Python is needed.

## Test plan
- [x] `gauge run e2e/specs/import_write.spec` — 2 scenarios passed locally.
- [x] CI E2E job stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)