### PR TITLE
Install gauge in Claude Code on the Web setup

### DIFF
--- a/.claude/scripts/setup.sh
+++ b/.claude/scripts/setup.sh
@@ -12,7 +12,7 @@ echo "Install gh..."
 bun x gh-setup-hooks
 
 GAUGE_VERSION=1.6.28
-if ! command -v gauge &> /dev/null; then
+if ! command -v gauge &> /dev/null || [ "$(gauge --version | head -n 1 | awk '{print $NF}')" != "${GAUGE_VERSION}" ]; then
     echo "Install gauge ${GAUGE_VERSION}..."
     mkdir -p "${HOME}/.local/bin"
     curl -SsL -o /tmp/gauge.zip "https://github.com/getgauge/gauge/releases/download/v${GAUGE_VERSION}/gauge-${GAUGE_VERSION}-linux.x86_64.zip"

--- a/.claude/scripts/setup.sh
+++ b/.claude/scripts/setup.sh
@@ -11,6 +11,21 @@ echo "Setting up Claude Code on the Web environment..."
 echo "Install gh..."
 bun x gh-setup-hooks
 
+GAUGE_VERSION=1.6.28
+if ! command -v gauge &> /dev/null; then
+    echo "Install gauge ${GAUGE_VERSION}..."
+    mkdir -p "${HOME}/.local/bin"
+    curl -SsL -o /tmp/gauge.zip "https://github.com/getgauge/gauge/releases/download/v${GAUGE_VERSION}/gauge-${GAUGE_VERSION}-linux.x86_64.zip"
+    unzip -o /tmp/gauge.zip -d "${HOME}/.local/bin"
+    rm /tmp/gauge.zip
+    export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+echo "Install gauge plugins..."
+gauge install python
+gauge install html-report
+gauge install screenshot
+
 if [ ! -d "${PROJECT_DIR}/.venv" ]; then
     echo "Create Python virtual environment..."
     uv sync --group dev --frozen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,10 @@
   git remote set-url origin https://github.com/ftnext/cdcasasagi.git
   ```
 - When a review comment is dismissed during auto-fix (judged as no action needed), reply to that comment with the reason. Write the reply in the same language as the original comment.
+- `gauge` is installed on the web runner, but its Python runner (`getgauge`)
+  only lives in `.venv`. Invoke via `uv run` so the venv's Python is used, and
+  set `CLAUDE_DESKTOP_CONFIG` to a throwaway path to bypass the safety guard in
+  `e2e/step_impl/steps_common.py`:
+  ```bash
+  cd e2e && CLAUDE_DESKTOP_CONFIG=/tmp/test-claude-config.json uv run gauge run specs
+  ```


### PR DESCRIPTION
## Summary
- Download the gauge 1.6.28 linux tarball into `~/.local/bin` during `.claude/scripts/setup.sh`.
- Install the `python`, `html-report`, and `screenshot` plugins so e2e specs can run in the web environment, matching the CI setup in `.github/workflows/e2e_v2.yml`.

## Test plan
- [x] Launch Claude Code on the Web on this branch and confirm `gauge --version` returns 1.6.28.
- [x] Confirm `gauge run specs` works under `e2e/` in the web environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)