### PR TITLE
Make validate-import read-only; hand off via import - --write

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ The goal for layer 2 is *"paste and done"*. This shapes command design:
 
 - Commands intended for developer composition keep the preview-first / `--write`-to-mutate shape.
 - Commands shared with non-developers must be expressible as a single copy-paste string with `--write` already included; the non-developer never sees a preview step.
-- `validate-import` intentionally has no `--write` option: it is the developer's composition tool for validating JSONL shared by the non-developer, and saves to a predictable path so the follow-up `import --write` command can also be handed over as a fixed string. Splitting the two keeps the non-developer path a sequence of pure copy-pastes.
+- `validate-import` intentionally has no `--write` option and never writes any files: it is the developer's read-only composition tool for checking that a JSONL snippet is schema-valid before sharing it. The non-developer handoff is a single `cdcasasagi import - --write` copy-paste into which they paste the JSONL directly — stdin replaces the earlier "stage a file, then import it" two-step.
 
 When adding a new command, decide which layer it serves and whether it participates in the developer-to-non-developer handoff. See `docs/author-workflow.md` for the concrete flow that motivated this model.
 

--- a/README.md
+++ b/README.md
@@ -70,31 +70,35 @@ Each line is a JSON object with a required `url` key and optional `name` / `tran
 {"url": "https://example.com/mcp"}
 ```
 
-Stdin is also supported:
+Stdin is also supported — pipe a file, or pass `-` and paste the JSONL interactively:
 
 ```
 cat servers.jsonl | cdcasasagi import -
 ```
 
+```
+cdcasasagi import - --write
+# Paste JSONL, then press Enter on a blank line to finish
+# (Ctrl+D / Ctrl+Z also works)
+```
+
 ### validate-import
 
-Validate a JSONL file without importing:
+Validate a JSONL file's schema without importing. This command never writes any files.
 
 ```
 cdcasasagi validate-import servers.jsonl
 ```
 
-Paste JSONL from stdin instead of preparing a file. When reading from stdin, the validated content is also saved to `./mcp-servers.jsonl` so you can hand it to `import`:
+Paste JSONL from stdin instead of preparing a file:
 
 ```
 cdcasasagi validate-import -
 # Paste JSONL, then press Enter on a blank line to finish
 # (Ctrl+D / Ctrl+Z also works)
-
-cdcasasagi import ./mcp-servers.jsonl --write
 ```
 
-Use `--output` (`-o`) to save to a different path. An existing file at the target path is overwritten without prompting.
+Once the JSONL validates, feed the same content to `import - --write` to apply it.
 
 ### revert
 

--- a/docs/author-workflow.md
+++ b/docs/author-workflow.md
@@ -42,20 +42,18 @@ The baseline flow is:
 
 The stumbling point is step 4. The author typically shares JSONL through chat tools or documentation tools — as *text*, not as an attached file. Asking a non-developer to take that text and save it to a file at a known path (with the right filename, no trailing whitespace, correct line endings) is exactly the kind of friction cdcasasagi is meant to remove.
 
-`validate-import -` exists to close that gap. The non-developer pastes the shared JSONL into `validate-import -`, which both validates it and writes it out to a predictable path (`./mcp-servers.jsonl`). From there, the pre-shared `import --write` command works without any manual file-saving step.
+`import -` closes that gap. The non-developer pastes the shared JSONL directly into `cdcasasagi import - --write` — no intermediate file, no saving step. One copy-paste command, one paste of the JSONL.
 
 So the handoff the author actually sends is:
 
 ```
-cdcasasagi validate-import -
-# paste the JSONL, Ctrl+D
-
-cdcasasagi import ./mcp-servers.jsonl --write
+cdcasasagi import - --write
+# paste the JSONL, Ctrl+D (or blank line)
 ```
 
-Both lines are pure copy-paste for the non-developer; the only keyboard action in between is pasting the JSONL and pressing Ctrl+D.
+The only keyboard action is pasting the JSONL and terminating stdin.
 
-`validate-import` deliberately has no `--write` option. Its role here is "validate + stage a file at a known path", not "mutate the config" — keeping those concerns split is what makes the two-step handoff readable as two pure copy-pastes.
+`validate-import` is the *author's* composition tool. Before sharing the JSONL, the author can paste it into `cdcasasagi validate-import -` locally to confirm schema / URL validity without touching their own config. `validate-import` deliberately has no `--write` option and does not write any files — it is strictly a read-only validator, keeping "validate" and "mutate the config" as separate concerns.
 
 ## Recovery
 
@@ -73,6 +71,6 @@ When the author (or another developer) adds a new command, the questions that fa
 
 - Is this for the author's local composition, or will it be handed to a non-developer as a finalized string?
 - If handed off, can it be expressed as a single copy-paste `--write` command?
-- If it stages state for a later command (like `validate-import -` staging `./mcp-servers.jsonl`), is the staging path predictable enough that the follow-up command can be given as a fixed string?
+- If the command needs input beyond arguments (e.g. JSONL content), can that input be delivered via stdin (`-`) in the same paste-and-done motion, rather than asking the non-developer to stage a file?
 
 Commands that cannot be reduced to a copy-paste string should stay in the author's local composition toolkit rather than being surfaced to non-developers.

--- a/e2e/specs/handoff.spec
+++ b/e2e/specs/handoff.spec
@@ -1,10 +1,10 @@
-# cdcasasagi handoff (validate-import - -> import --write -> revert)
+# cdcasasagi handoff (validate-import -> import - --write -> revert)
 
 tags: handoff
 
 E2E for the non-developer handoff journey described in `docs/author-workflow.md`:
-paste JSONL into `validate-import -`, run `import --write`, and `revert` as the
-escape hatch.
+validate the JSONL locally with `validate-import -`, paste the same JSONL into
+`import - --write`, and `revert` as the escape hatch.
 
 ## Paste JSONL, import --write, then revert back to the empty initial state
 
@@ -14,8 +14,12 @@ escape hatch.
      |-----------------------------------|---------------------|
      |https://developers.openai.com/mcp  |openai-developer-docs|
      |https://mcp.notion.com/mcp         |                     |
-* The staging file "mcp-servers.jsonl" is created
-* Run cdcasasagi "import ./mcp-servers.jsonl --write"
+* No staging file "mcp-servers.jsonl" is created
+* Run cdcasasagi "import - --write" with the following JSONL piped to stdin
+     |url                                |name                 |
+     |-----------------------------------|---------------------|
+     |https://developers.openai.com/mcp  |openai-developer-docs|
+     |https://mcp.notion.com/mcp         |                     |
 * "openai-developer-docs,notion" entries are written to the config file
 * The backup file is created
 * Run cdcasasagi "revert"

--- a/e2e/step_impl/steps_handoff.py
+++ b/e2e/step_impl/steps_handoff.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from getgauge.python import after_scenario, data_store, step
+from getgauge.python import data_store, step
 
 from cdcasasagi.desktop_config import config_path
 
@@ -28,13 +28,12 @@ def run_cdcasasagi_with_jsonl(args, table):
     cmd = [sys.executable, "-m", "cdcasasagi"] + shlex.split(args)
     result = subprocess.run(cmd, input=stdin_input, capture_output=True, text=True)
     data_store.scenario["last_result"] = result
-    data_store.scenario["staging_jsonl_cleanup"] = True
 
 
-@step("The staging file <path> is created")
-def assert_staging_file_created(path):
+@step("No staging file <path> is created")
+def assert_staging_file_not_created(path):
     staged = Path(path)
-    assert staged.is_file(), f"staging file not created: {staged.resolve()}"
+    assert not staged.exists(), f"unexpected staging file: {staged.resolve()}"
 
 
 @step("The config file has no MCP server entries")
@@ -42,12 +41,3 @@ def assert_config_has_no_entries():
     config = json.loads(config_path().read_text(encoding="utf-8"))
     servers = config.get("mcpServers", {})
     assert servers == {}, f"expected no mcpServers entries, got {servers}"
-
-
-@after_scenario("<handoff>")
-def cleanup_staging_jsonl():
-    if not data_store.scenario.get("staging_jsonl_cleanup"):
-        return
-    staged = Path("mcp-servers.jsonl")
-    if staged.is_file():
-        staged.unlink()

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -334,18 +334,9 @@ def _resolve_import_entries(
 @app.command(name="validate-import")
 def validate_import(
     file: str = typer.Argument(..., help="Path to JSONL file (use - for stdin)"),
-    output_path: Path = typer.Option(
-        Path("mcp-servers.jsonl"),
-        "--output",
-        "-o",
-        help=(
-            "Path to save validated JSONL when reading from stdin "
-            "(default: ./mcp-servers.jsonl; ignored when FILE is a file path)"
-        ),
-    ),
 ) -> None:
-    """Validate a JSONL import file. When reading from stdin (-), save it as a JSONL file for later 'import'."""
-    raw_entries, source_label, raw_text = _parse_import_file(file)
+    """Validate a JSONL import file. Does not write any files."""
+    raw_entries, source_label, _ = _parse_import_file(file)
 
     schema_errors = _validate_import_schema(raw_entries)
 
@@ -364,20 +355,7 @@ def validate_import(
         )
         raise typer.Exit(code=1)
 
-    saved_path: Path | None = None
-    if file == "-":
-        try:
-            output_path.write_text(raw_text, encoding="utf-8")
-        except OSError as e:
-            typer.echo(f"Cannot write output file: {output_path}\n{e}", err=True)
-            raise typer.Exit(code=1)
-        saved_path = output_path
-
-    typer.echo(
-        output.validate_ok_message(
-            source_label, len(raw_entries), validated, saved_path
-        )
-    )
+    typer.echo(output.validate_ok_message(source_label, len(raw_entries), validated))
 
 
 # ------------------------------------------------------------------

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -210,15 +210,12 @@ def validate_ok_message(
     source: str,
     entry_count: int,
     resolved: list[tuple[str, str, str]],
-    saved_path: Path | None = None,
 ) -> str:
     entry_word = "entry" if entry_count == 1 else "entries"
     lines: list[str] = [f"Valid: {source} ({entry_count} {entry_word})", ""]
     max_name = max((len(n) for n, _, _ in resolved), default=0)
     for name, url, _transport in resolved:
         lines.append(f"  {name.ljust(max_name)}  {url}")
-    if saved_path is not None:
-        lines.extend(["", f"Saved: {saved_path}"])
     return "\n".join(lines)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -421,6 +421,15 @@ class TestImportWrite:
         assert "notion" in data["mcpServers"]
         assert data["other"] == "keep"
 
+    def test_write_from_stdin(self, config_env):
+        config_file, _ = config_env
+        stdin_data = '{"url": "https://mcp.notion.com/mcp"}\n'
+        result = runner.invoke(app, ["import", "-", "--write"], input=stdin_data)
+        assert result.exit_code == 0
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert "notion" in data["mcpServers"]
+
     def test_write_all_identical_no_write(self, config_env, tmp_path):
         config_file, fake_proxy = config_env
         entry = {
@@ -676,45 +685,22 @@ class TestValidate:
         result = runner.invoke(app, ["validate-import", str(f)])
         assert result.exit_code == 0
 
-    def test_stdin_saves_to_default_path(self, validate_env, tmp_path):
+    def test_stdin_validates_without_writing_file(self, validate_env, tmp_path):
         jsonl = '{"url": "https://mcp.notion.com/mcp"}\n'
         result = runner.invoke(app, ["validate-import", "-"], input=jsonl)
         assert result.exit_code == 0
         assert "Valid:" in result.output
         assert "stdin" in result.output
-        saved = tmp_path / "mcp-servers.jsonl"
-        assert saved.exists()
-        assert saved.read_text(encoding="utf-8") == jsonl
-        assert "Saved: mcp-servers.jsonl" in result.output
-
-    def test_stdin_output_option(self, validate_env, tmp_path):
-        jsonl = '{"url": "https://mcp.notion.com/mcp"}\n'
-        dest = tmp_path / "custom.jsonl"
-        result = runner.invoke(
-            app, ["validate-import", "-", "--output", str(dest)], input=jsonl
-        )
-        assert result.exit_code == 0
-        assert dest.exists()
-        assert dest.read_text(encoding="utf-8") == jsonl
-        # Default file must NOT be created when --output is specified.
+        assert "Saved:" not in result.output
         assert not (tmp_path / "mcp-servers.jsonl").exists()
 
-    def test_stdin_overwrites_existing_file(self, validate_env, tmp_path):
+    def test_stdin_does_not_touch_existing_file(self, validate_env, tmp_path):
         existing = tmp_path / "mcp-servers.jsonl"
         existing.write_text("old content\n", encoding="utf-8")
         jsonl = '{"url": "https://mcp.notion.com/mcp"}\n'
         result = runner.invoke(app, ["validate-import", "-"], input=jsonl)
         assert result.exit_code == 0
-        assert existing.read_text(encoding="utf-8") == jsonl
-
-    def test_stdin_short_output_flag(self, validate_env, tmp_path):
-        jsonl = '{"url": "https://mcp.notion.com/mcp"}\n'
-        dest = tmp_path / "short.jsonl"
-        result = runner.invoke(
-            app, ["validate-import", "-", "-o", str(dest)], input=jsonl
-        )
-        assert result.exit_code == 0
-        assert dest.read_text(encoding="utf-8") == jsonl
+        assert existing.read_text(encoding="utf-8") == "old content\n"
 
     def test_file_input_does_not_save(self, validate_env, tmp_path):
         f = tmp_path / "servers.jsonl"


### PR DESCRIPTION
## Summary

非開発者への JSONL 受け渡しフローを「2 段構え」から「1 コマンドのペースト」に簡略化する変更です。

### これまで

`docs/author-workflow.md` で推奨していた手順は 2 コマンド:

```
cdcasasagi validate-import -   # ペースト→ ./mcp-servers.jsonl に保存（ステージング）
cdcasasagi import ./mcp-servers.jsonl --write
```

`validate-import -` は「検証」+「既知パスへのファイル書き出し」を兼ねていて、後続の `import --write` が固定文字列で共有できるように仕組みを組んでいました。

### これから

`import` コマンドは既に `-` を介した stdin 対話ペーストに対応しているため、そちらに一本化します。

```
cdcasasagi import - --write
# ペースト→ Ctrl+D / 空行 Enter
```

`validate-import` は **作者（開発者）側の composition 専用ツール** に純化します。ペーストされた JSONL のスキーマ/URL 検証だけを行い、ファイル書き出しはしません。作者は共有前に手元で `validate-import -` に流し込んで検証し、問題なければ JSONL と `import - --write` コマンドを非開発者に渡す、という役割分担です。

AGENTS.md の Audience & Distribution Model（\"paste and done\"）の観点では、非開発者側のキーボード操作が「1 コマンドをコピペ → JSONL をペースト → Ctrl+D」の 1 回に減り、より「paste and done」に近づきます。staging ファイルの経路が消えることで「中間ファイルが残っているか」「ファイル名が衝突しないか」といった副作用を考えなくて済む利点もあります。

## Changes

- `src/cdcasasagi/cli.py`: `validate-import` から `--output`/`-o` オプションと stdin → ファイル書き出しの分岐を削除。
- `src/cdcasasagi/output.py`: `validate_ok_message` から `saved_path` 引数と `Saved:` 行を削除。
- `tests/test_cli.py`:
  - `validate-import -` の stdin 入力で `./mcp-servers.jsonl` が **作られない** ことを検証するテストに置き換え。
  - `--output` / `-o` を使う 2 ケースを削除（オプション自体が消えたため）。
  - `import - --write` を stdin 経由で実行し、config が書き込まれることを確認するテストを追加。
- `README.md` / `docs/author-workflow.md` / `AGENTS.md`: handoff フローと「新しいコマンドを追加するときのチェックリスト」を stdin-in-one-paste 前提に書き換え。
- `e2e/specs/handoff.spec` + `e2e/step_impl/steps_handoff.py`:
  - 新フローに合わせてシナリオを書き換え。
  - \"The staging file 'mcp-servers.jsonl' is created\" ステップを \"No staging file 'mcp-servers.jsonl' is created\" に反転（後悔回帰防止）。
  - staging ファイル用の `after_scenario` クリーンアップを削除（ファイル自体を作らなくなったため）。

## Non-changes

- `import` コマンド本体は既に stdin `-` に対応済みで、今回は実装変更なし（stdin 経由 `--write` のテストを追加しただけ）。
- `validate-import` の終了コード・検証メッセージのフォーマットは従来通り（`Saved:` 行だけが消える）。
- トップレベル JSON キーの扱い、`mcp-proxy` 解決、`.bak`/`revert` 動作には一切触っていません。

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest -q` → 171 passed
- [x] CI 上の e2e（Gauge）が新シナリオで通ること
- [x] 手動確認（web runner 等）:
  ```bash
  # validate-import - がファイルを作らないこと
  rm -f mcp-servers.jsonl
  printf '{\"url\":\"https://example.com/mcp\"}\n' | uv run --no-sync cdcasasagi validate-import -
  test ! -f mcp-servers.jsonl && echo OK

  # import - --write（tmp config で）
  CLAUDE_DESKTOP_CONFIG=\$(mktemp) \
    printf '{\"url\":\"https://example.com/mcp\"}\n' \
    | uv run --no-sync cdcasasagi import - --write
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)