### PR TITLE
import: treat existing-URL under a different name as a conflict

### DIFF
--- a/e2e/specs/import_conflict.spec
+++ b/e2e/specs/import_conflict.spec
@@ -36,3 +36,31 @@ entry would be classified as "identical", not "conflict").
    |https://developers.openai.com/mcp|
 * "notion,developers" entries are written to the config file
 * The transport of "notion" in the config file is "streamablehttp"
+
+## A different name for an existing URL is a conflict without --force
+
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* "notion" entry is written to the config file
+* Pipe JSONL to cdcasasagi "import - --write"
+
+   |url                              |name     |
+   |---------------------------------|---------|
+   |https://mcp.notion.com/mcp       |my-notion|
+   |https://developers.openai.com/mcp|         |
+* The last command fails
+* The config file is unchanged since the last write
+
+## --force --write replaces the existing URL entry under the new name
+
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* "notion" entry is written to the config file
+* Pipe JSONL to cdcasasagi "import - --force --write"
+
+   |url                              |name     |
+   |---------------------------------|---------|
+   |https://mcp.notion.com/mcp       |my-notion|
+   |https://developers.openai.com/mcp|         |
+* "my-notion,developers" entries are written to the config file
+* "notion" entry does not exist in the config file

--- a/e2e/step_impl/steps_import_conflict.py
+++ b/e2e/step_impl/steps_import_conflict.py
@@ -13,7 +13,17 @@ from cdcasasagi.desktop_config import config_path
 @step("Pipe JSONL to cdcasasagi <args> <table>")
 def pipe_jsonl_to_cdcasasagi(args, table):
     urls = table.get_column_values_with_name("url")
-    stdin_text = "".join(json.dumps({"url": url}) + "\n" for url in urls)
+    headers = set(table.headers)
+    names = table.get_column_values_with_name("name") if "name" in headers else None
+
+    lines: list[str] = []
+    for i, url in enumerate(urls):
+        obj: dict[str, str] = {"url": url}
+        if names is not None and names[i]:
+            obj["name"] = names[i]
+        lines.append(json.dumps(obj))
+    stdin_text = "\n".join(lines) + "\n"
+
     cmd = [sys.executable, "-m", "cdcasasagi"] + shlex.split(args)
     result = subprocess.run(cmd, capture_output=True, text=True, input=stdin_text)
     data_store.scenario["last_result"] = result
@@ -27,4 +37,12 @@ def assert_entry_transport(name, transport):
     args = entry.get("args", [])
     assert len(args) >= 2 and args[0] == "--transport" and args[1] == transport, (
         f'expected transport {transport!r} for "{name}", got args={args!r}'
+    )
+
+
+@step("<name> entry does not exist in the config file")
+def assert_entry_missing(name):
+    config = json.loads(config_path().read_text(encoding="utf-8"))
+    assert name not in config.get("mcpServers", {}), (
+        f'entry "{name}" unexpectedly present in config'
     )

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -396,14 +396,15 @@ def import_cmd(
     # Phase 2: Planning
     plan = desktop_config.plan_import(current_config, resolved)
 
-    existing_servers = current_config.get("mcpServers", {})
-    plan_for_output: list[tuple[str, str, str, str | None]] = []
+    plan_for_output: list[tuple[str, str, str, list[str]]] = []
     for (name, action, _entry), (_n, url, _e) in zip(plan, resolved):
-        replaces: str | None = None
-        if action == "conflict" and name not in existing_servers:
-            aliases = desktop_config.find_entry_names_by_url(current_config, url)
-            if aliases:
-                replaces = aliases[0]
+        replaces: list[str] = []
+        if action == "conflict":
+            replaces = [
+                n
+                for n in desktop_config.find_entry_names_by_url(current_config, url)
+                if n != name
+            ]
         plan_for_output.append((name, action, url, replaces))
 
     conflicts = [name for name, action, _ in plan if action == "conflict"]

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -394,13 +394,17 @@ def import_cmd(
         raise typer.Exit(code=1)
 
     # Phase 2: Planning
-    entries_for_plan = [(name, entry) for name, _url, entry in resolved]
-    plan = desktop_config.plan_import(current_config, entries_for_plan)
+    plan = desktop_config.plan_import(current_config, resolved)
 
-    plan_for_output: list[tuple[str, str, str]] = [
-        (name, action, url)
-        for (name, action, _entry), (_n, url, _e) in zip(plan, resolved)
-    ]
+    existing_servers = current_config.get("mcpServers", {})
+    plan_for_output: list[tuple[str, str, str, str | None]] = []
+    for (name, action, _entry), (_n, url, _e) in zip(plan, resolved):
+        replaces: str | None = None
+        if action == "conflict" and name not in existing_servers:
+            aliases = desktop_config.find_entry_names_by_url(current_config, url)
+            if aliases:
+                replaces = aliases[0]
+        plan_for_output.append((name, action, url, replaces))
 
     conflicts = [name for name, action, _ in plan if action == "conflict"]
     if conflicts and not force:

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -396,16 +396,28 @@ def import_cmd(
     # Phase 2: Planning
     plan = desktop_config.plan_import(current_config, resolved)
 
+    # Build plan_for_output by simulating apply_import row by row so `replaces`
+    # reflects the state each row will actually see (earlier rows may have
+    # already deleted or rewritten entries this row would otherwise claim).
+    working = json.loads(json.dumps(current_config))
+    if "mcpServers" not in working:
+        working["mcpServers"] = {}
+
     plan_for_output: list[tuple[str, str, str, list[str]]] = []
-    for (name, action, _entry), (_n, url, _e) in zip(plan, resolved):
+    for (name, action, entry), (_n, url, _e) in zip(plan, resolved):
         replaces: list[str] = []
         if action == "conflict":
             replaces = [
                 n
-                for n in desktop_config.find_entry_names_by_url(current_config, url)
+                for n in desktop_config.find_entry_names_by_url(working, url)
                 if n != name
             ]
         plan_for_output.append((name, action, url, replaces))
+
+        if action == "add" or (action == "conflict" and force):
+            for r in replaces:
+                del working["mcpServers"][r]
+            working["mcpServers"][name] = entry
 
     conflicts = [name for name, action, _ in plan if action == "conflict"]
     if conflicts and not force:

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -126,22 +126,27 @@ def merge_entry(
 
 def plan_import(
     config: dict[str, Any],
-    entries: list[tuple[str, dict[str, Any]]],
+    entries: list[tuple[str, str, dict[str, Any]]],
 ) -> list[tuple[str, str, dict[str, Any]]]:
     """Classify import entries against current config.
 
-    Returns list of ``(name, action, entry)`` where *action* is one of
-    ``'add'``, ``'identical'``, or ``'conflict'``.
+    *entries* is a list of ``(name, url, entry)``. Returns a list of
+    ``(name, action, entry)`` where *action* is one of ``'add'``,
+    ``'identical'``, or ``'conflict'``. A URL that already exists in the
+    config under a different name counts as a conflict.
     """
     servers = config.get("mcpServers", {})
     plan: list[tuple[str, str, dict[str, Any]]] = []
-    for name, entry in entries:
-        if name not in servers:
-            plan.append((name, "add", entry))
-        elif servers[name] == entry:
-            plan.append((name, "identical", entry))
-        else:
+    for name, url, entry in entries:
+        if name in servers:
+            if servers[name] == entry:
+                plan.append((name, "identical", entry))
+            else:
+                plan.append((name, "conflict", entry))
+        elif find_entry_names_by_url(config, url):
             plan.append((name, "conflict", entry))
+        else:
+            plan.append((name, "add", entry))
     return plan
 
 
@@ -150,12 +155,24 @@ def apply_import(
     plan: list[tuple[str, str, dict[str, Any]]],
     force: bool,
 ) -> dict[str, Any]:
-    """Apply an import plan – adds new entries and overwrites conflicts when *force*."""
+    """Apply an import plan – adds new entries and overwrites conflicts when *force*.
+
+    On a URL alias conflict (new name, existing URL under another name),
+    ``--force`` removes the aliased entry before writing the new one.
+    """
     config = json.loads(json.dumps(config))  # deep copy
     if "mcpServers" not in config:
         config["mcpServers"] = {}
     for name, action, entry in plan:
-        if action == "add" or (action == "conflict" and force):
+        if action == "add":
+            config["mcpServers"][name] = entry
+        elif action == "conflict" and force:
+            args = entry.get("args", [])
+            if args:
+                url = args[-1]
+                for other in find_entry_names_by_url(config, url):
+                    if other != name:
+                        del config["mcpServers"][other]
             config["mcpServers"][name] = entry
     return config
 

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -95,11 +95,15 @@ def write_message(
     return "\n".join(lines)
 
 
+def _format_replaces(replaces: list[str]) -> str:
+    return ", ".join(f'"{n}"' for n in replaces)
+
+
 def import_preview_message(
     config_path: Path,
     source: str,
     entry_count: int,
-    plan: list[tuple[str, str, str, str | None]],
+    plan: list[tuple[str, str, str, list[str]]],
     force: bool,
     verbose_diff: str | None = None,
 ) -> str:
@@ -126,15 +130,20 @@ def import_preview_message(
             if force:
                 if replaces:
                     lines.append(
-                        f'  ~ {padded}  {url}  (overwrite, replaces "{replaces}")'
+                        f"  ~ {padded}  {url}  "
+                        f"(overwrite, replaces {_format_replaces(replaces)})"
                     )
                 else:
                     lines.append(f"  ~ {padded}  {url}  (overwrite)")
                 counts["overwrite"] += 1
             else:
                 if replaces:
+                    label = (
+                        "URL already under" if len(replaces) == 1 else "URL shared with"
+                    )
                     lines.append(
-                        f'  ! {padded}  {url}  (URL already under "{replaces}", '
+                        f"  ! {padded}  {url}  "
+                        f"({label} {_format_replaces(replaces)}, "
                         "use --force to overwrite)"
                     )
                 else:
@@ -174,7 +183,7 @@ def import_preview_message(
 def import_write_message(
     config_path: Path,
     source: str,
-    plan: list[tuple[str, str, str, str | None]],
+    plan: list[tuple[str, str, str, list[str]]],
     force: bool,
     file_existed: bool,
 ) -> str:
@@ -195,7 +204,7 @@ def import_write_message(
             lines.append(f"  = {name} (unchanged)")
         elif action == "conflict" and force:
             if replaces:
-                lines.append(f'  ~ {name} (replaced "{replaces}")')
+                lines.append(f"  ~ {name} (replaced {_format_replaces(replaces)})")
             else:
                 lines.append(f"  ~ {name}")
             overwrite_count += 1

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -99,7 +99,7 @@ def import_preview_message(
     config_path: Path,
     source: str,
     entry_count: int,
-    plan: list[tuple[str, str, str]],
+    plan: list[tuple[str, str, str, str | None]],
     force: bool,
     verbose_diff: str | None = None,
 ) -> str:
@@ -110,11 +110,11 @@ def import_preview_message(
     lines.append("")
     lines.append("Plan:")
 
-    max_name_len = max((len(n) for n, _, _ in plan), default=0)
+    max_name_len = max((len(n) for n, _, _, _ in plan), default=0)
 
     counts: dict[str, int] = {"add": 0, "identical": 0, "conflict": 0, "overwrite": 0}
 
-    for name, action, url in plan:
+    for name, action, url, replaces in plan:
         padded = name.ljust(max_name_len)
         if action == "add":
             lines.append(f"  + {padded}  {url}")
@@ -124,12 +124,23 @@ def import_preview_message(
             counts["identical"] += 1
         elif action == "conflict":
             if force:
-                lines.append(f"  ~ {padded}  {url}  (overwrite)")
+                if replaces:
+                    lines.append(
+                        f'  ~ {padded}  {url}  (overwrite, replaces "{replaces}")'
+                    )
+                else:
+                    lines.append(f"  ~ {padded}  {url}  (overwrite)")
                 counts["overwrite"] += 1
             else:
-                lines.append(
-                    f"  ! {padded}  {url}  (name conflict, use --force to overwrite)"
-                )
+                if replaces:
+                    lines.append(
+                        f'  ! {padded}  {url}  (URL already under "{replaces}", '
+                        "use --force to overwrite)"
+                    )
+                else:
+                    lines.append(
+                        f"  ! {padded}  {url}  (name conflict, use --force to overwrite)"
+                    )
                 counts["conflict"] += 1
 
     lines.append("")
@@ -150,8 +161,9 @@ def import_preview_message(
         lines.append(verbose_diff.rstrip())
 
     if counts["conflict"] > 0:
+        conflict_word = "conflict" if counts["conflict"] == 1 else "conflicts"
         lines.append(
-            f"Error: {counts['conflict']} name conflict without --force. Aborting."
+            f"Error: {counts['conflict']} {conflict_word} without --force. Aborting."
         )
     else:
         lines.append("This is a preview. Re-run with --write to apply.")
@@ -162,7 +174,7 @@ def import_preview_message(
 def import_write_message(
     config_path: Path,
     source: str,
-    plan: list[tuple[str, str, str]],
+    plan: list[tuple[str, str, str, str | None]],
     force: bool,
     file_existed: bool,
 ) -> str:
@@ -175,14 +187,17 @@ def import_write_message(
     add_count = 0
     overwrite_count = 0
 
-    for name, action, _url in plan:
+    for name, action, _url, replaces in plan:
         if action == "add":
             lines.append(f"  + {name}")
             add_count += 1
         elif action == "identical":
             lines.append(f"  = {name} (unchanged)")
         elif action == "conflict" and force:
-            lines.append(f"  ~ {name}")
+            if replaces:
+                lines.append(f'  ~ {name} (replaced "{replaces}")')
+            else:
+                lines.append(f"  ~ {name}")
             overwrite_count += 1
 
     lines.append("")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -469,6 +469,62 @@ class TestImportConflicts:
         data = json.loads(config_file.read_text())
         assert data["mcpServers"]["notion"]["command"] == str(fake_proxy)
 
+    def test_url_alias_conflict_without_force_aborts(self, config_env, tmp_path):
+        """Same URL under a different name is a conflict; no --force → fail, no write."""
+        config_file, fake_proxy = config_env
+        entry = {
+            "command": str(fake_proxy),
+            "args": ["--transport", "streamablehttp", "https://mcp.notion.com/mcp"],
+        }
+        original = {"mcpServers": {"notion": entry}}
+        config_file.write_text(json.dumps(original))
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text(
+            '{"url": "https://mcp.notion.com/mcp", "name": "my-notion"}\n'
+        )
+        result = runner.invoke(app, ["import", str(input_file), "--write"])
+        assert result.exit_code == 1
+        assert "my-notion" in result.output
+        assert '"notion"' in result.output
+        assert "--force" in result.output
+        assert json.loads(config_file.read_text()) == original
+
+    def test_url_alias_conflict_with_force_replaces(self, config_env, tmp_path):
+        """`--force` removes the existing alias and writes under the new name."""
+        config_file, fake_proxy = config_env
+        entry = {
+            "command": str(fake_proxy),
+            "args": ["--transport", "streamablehttp", "https://mcp.notion.com/mcp"],
+        }
+        config_file.write_text(json.dumps({"mcpServers": {"notion": entry}}))
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text(
+            '{"url": "https://mcp.notion.com/mcp", "name": "my-notion"}\n'
+        )
+        result = runner.invoke(app, ["import", str(input_file), "--force", "--write"])
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        assert "my-notion" in data["mcpServers"]
+        assert "notion" not in data["mcpServers"]
+
+    def test_url_alias_conflict_all_or_nothing(self, config_env, tmp_path):
+        """Mixed input: URL alias conflict + new URL — without --force nothing is written."""
+        config_file, fake_proxy = config_env
+        entry = {
+            "command": str(fake_proxy),
+            "args": ["--transport", "streamablehttp", "https://mcp.notion.com/mcp"],
+        }
+        original = {"mcpServers": {"notion": entry}}
+        config_file.write_text(json.dumps(original))
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text(
+            '{"url": "https://mcp.notion.com/mcp", "name": "my-notion"}\n'
+            '{"url": "https://developers.openai.com/mcp"}\n'
+        )
+        result = runner.invoke(app, ["import", str(input_file), "--write"])
+        assert result.exit_code == 1
+        assert json.loads(config_file.read_text()) == original
+
     def test_identical_never_conflicts(self, config_env, tmp_path):
         config_file, fake_proxy = config_env
         entry = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -507,6 +507,45 @@ class TestImportConflicts:
         assert "my-notion" in data["mcpServers"]
         assert "notion" not in data["mcpServers"]
 
+    def test_same_name_conflict_reports_url_alias_removal(self, config_env, tmp_path):
+        """Same-name conflict whose URL is held by another entry: the plan output
+        must mention the aliased entry that --force will delete."""
+        config_file, fake_proxy = config_env
+        notion_url = "https://mcp.notion.com/mcp"
+        other_url = "https://other.example.com/mcp"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": {
+                            "command": str(fake_proxy),
+                            "args": ["--transport", "streamablehttp", notion_url],
+                        },
+                        "other": {
+                            "command": str(fake_proxy),
+                            "args": ["--transport", "streamablehttp", other_url],
+                        },
+                    }
+                }
+            )
+        )
+        # Re-target "notion" to the URL currently held by "other".
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text(f'{{"url": "{other_url}", "name": "notion"}}\n')
+
+        # Preview: warns that "other" would be removed alongside the notion overwrite.
+        result = runner.invoke(app, ["import", str(input_file)])
+        assert result.exit_code == 1
+        assert '"other"' in result.output
+
+        # --force --write: plan announces the removal and config actually loses "other".
+        result = runner.invoke(app, ["import", str(input_file), "--force", "--write"])
+        assert result.exit_code == 0
+        assert 'replaced "other"' in result.output
+        data = json.loads(config_file.read_text())
+        assert "other" not in data["mcpServers"]
+        assert data["mcpServers"]["notion"]["args"][-1] == other_url
+
     def test_url_alias_conflict_all_or_nothing(self, config_env, tmp_path):
         """Mixed input: URL alias conflict + new URL — without --force nothing is written."""
         config_file, fake_proxy = config_env

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,6 +546,53 @@ class TestImportConflicts:
         assert "other" not in data["mcpServers"]
         assert data["mcpServers"]["notion"]["args"][-1] == other_url
 
+    def test_replaces_reflects_serial_apply(self, config_env, tmp_path):
+        """Row N's `replaces` is computed against the state after rows 0..N-1 apply.
+
+        Starting from ``{a:url1, b:url2}`` and importing ``a->url2, c->url1``:
+        row 1 overwrites ``a`` and removes ``b`` (replaces=["b"]). Row 2 then
+        adds ``c`` — by this point ``a`` already holds ``url2``, so ``c`` does
+        not actually remove anything and must not claim to replace ``a``.
+        """
+        config_file, fake_proxy = config_env
+        url1 = "https://one.example.com/mcp"
+        url2 = "https://two.example.com/mcp"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "a": {
+                            "command": str(fake_proxy),
+                            "args": ["--transport", "streamablehttp", url1],
+                        },
+                        "b": {
+                            "command": str(fake_proxy),
+                            "args": ["--transport", "streamablehttp", url2],
+                        },
+                    }
+                }
+            )
+        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text(
+            f'{{"url": "{url2}", "name": "a"}}\n{{"url": "{url1}", "name": "c"}}\n'
+        )
+
+        # --force preview: "a" replaces "b"; "c" must not claim to replace "a".
+        result = runner.invoke(app, ["import", str(input_file), "--force"])
+        assert result.exit_code == 0
+        assert 'replaces "b"' in result.output
+        assert 'replaces "a"' not in result.output
+
+        # --force --write: post-apply, "a" holds url2, "c" holds url1, "b" gone.
+        result = runner.invoke(app, ["import", str(input_file), "--force", "--write"])
+        assert result.exit_code == 0
+        assert 'replaced "a"' not in result.output
+        data = json.loads(config_file.read_text())
+        assert data["mcpServers"]["a"]["args"][-1] == url2
+        assert data["mcpServers"]["c"]["args"][-1] == url1
+        assert "b" not in data["mcpServers"]
+
     def test_url_alias_conflict_all_or_nothing(self, config_env, tmp_path):
         """Mixed input: URL alias conflict + new URL — without --force nothing is written."""
         config_file, fake_proxy = config_env

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -213,86 +213,143 @@ class TestRevertConfig:
         assert p.read_text().endswith("\n")
 
 
+def _entry(url: str, command: str = "x") -> dict:
+    return {"command": command, "args": ["--transport", "streamablehttp", url]}
+
+
 class TestPlanImport:
     def test_all_new(self):
         config = {"mcpServers": {}}
-        entries = [("a", {"command": "x"}), ("b", {"command": "y"})]
+        a_entry = _entry("https://a.example/mcp")
+        b_entry = _entry("https://b.example/mcp")
+        entries = [
+            ("a", "https://a.example/mcp", a_entry),
+            ("b", "https://b.example/mcp", b_entry),
+        ]
         plan = plan_import(config, entries)
         assert plan == [
-            ("a", "add", {"command": "x"}),
-            ("b", "add", {"command": "y"}),
+            ("a", "add", a_entry),
+            ("b", "add", b_entry),
         ]
 
     def test_identical(self):
-        config = {"mcpServers": {"a": {"command": "x"}}}
-        entries = [("a", {"command": "x"})]
+        a_entry = _entry("https://a.example/mcp")
+        config = {"mcpServers": {"a": a_entry}}
+        entries = [("a", "https://a.example/mcp", a_entry)]
         plan = plan_import(config, entries)
-        assert plan == [("a", "identical", {"command": "x"})]
+        assert plan == [("a", "identical", a_entry)]
 
-    def test_conflict(self):
-        config = {"mcpServers": {"a": {"command": "old"}}}
-        entries = [("a", {"command": "new"})]
+    def test_conflict_same_name(self):
+        old = _entry("https://a.example/mcp", command="old")
+        new = _entry("https://a.example/mcp", command="new")
+        config = {"mcpServers": {"a": old}}
+        entries = [("a", "https://a.example/mcp", new)]
         plan = plan_import(config, entries)
-        assert plan == [("a", "conflict", {"command": "new"})]
+        assert plan == [("a", "conflict", new)]
+
+    def test_conflict_url_under_different_name(self):
+        """Same URL, new name → conflict (not add)."""
+        url = "https://mcp.notion.com/mcp"
+        existing = _entry(url)
+        incoming = _entry(url, command="different")
+        config = {"mcpServers": {"notion": existing}}
+        entries = [("my-notion", url, incoming)]
+        plan = plan_import(config, entries)
+        assert plan == [("my-notion", "conflict", incoming)]
 
     def test_mixed(self):
-        config = {"mcpServers": {"existing": {"command": "x"}}}
+        existing = _entry("https://existing.example/mcp")
+        incoming_new = _entry("https://new.example/mcp")
+        config = {"mcpServers": {"existing": existing}}
         entries = [
-            ("existing", {"command": "x"}),  # identical
-            ("new", {"command": "y"}),  # add
+            ("existing", "https://existing.example/mcp", existing),  # identical
+            ("new", "https://new.example/mcp", incoming_new),  # add
         ]
         plan = plan_import(config, entries)
         assert plan[0][1] == "identical"
         assert plan[1][1] == "add"
 
     def test_empty_mcpservers(self):
+        e = _entry("https://a.example/mcp")
         config = {"other": "value"}
-        entries = [("a", {"command": "x"})]
+        entries = [("a", "https://a.example/mcp", e)]
         plan = plan_import(config, entries)
-        assert plan == [("a", "add", {"command": "x"})]
+        assert plan == [("a", "add", e)]
 
 
 class TestApplyImport:
     def test_adds_new_entries(self):
         config = {"mcpServers": {}}
-        plan = [("a", "add", {"command": "x"}), ("b", "add", {"command": "y"})]
+        a = _entry("https://a.example/mcp")
+        b = _entry("https://b.example/mcp")
+        plan = [("a", "add", a), ("b", "add", b)]
         result = apply_import(config, plan, force=False)
         assert "a" in result["mcpServers"]
         assert "b" in result["mcpServers"]
 
     def test_skips_identical(self):
-        config = {"mcpServers": {"a": {"command": "x"}}}
-        plan = [("a", "identical", {"command": "x"})]
+        a = _entry("https://a.example/mcp")
+        config = {"mcpServers": {"a": a}}
+        plan = [("a", "identical", a)]
         result = apply_import(config, plan, force=False)
-        assert result["mcpServers"]["a"] == {"command": "x"}
+        assert result["mcpServers"]["a"] == a
 
     def test_skips_conflict_without_force(self):
-        config = {"mcpServers": {"a": {"command": "old"}}}
-        plan = [("a", "conflict", {"command": "new"})]
+        old = _entry("https://a.example/mcp", command="old")
+        new = _entry("https://a.example/mcp", command="new")
+        config = {"mcpServers": {"a": old}}
+        plan = [("a", "conflict", new)]
         result = apply_import(config, plan, force=False)
-        assert result["mcpServers"]["a"] == {"command": "old"}
+        assert result["mcpServers"]["a"] == old
 
     def test_overwrites_conflict_with_force(self):
-        config = {"mcpServers": {"a": {"command": "old"}}}
-        plan = [("a", "conflict", {"command": "new"})]
+        old = _entry("https://a.example/mcp", command="old")
+        new = _entry("https://a.example/mcp", command="new")
+        config = {"mcpServers": {"a": old}}
+        plan = [("a", "conflict", new)]
         result = apply_import(config, plan, force=True)
-        assert result["mcpServers"]["a"] == {"command": "new"}
+        assert result["mcpServers"]["a"] == new
+
+    def test_url_alias_conflict_force_removes_existing_alias(self):
+        """`--force` removes the aliased entry and writes under the new name."""
+        url = "https://mcp.notion.com/mcp"
+        existing = _entry(url)
+        incoming = _entry(url, command="new")
+        config = {"mcpServers": {"notion": existing}}
+        plan = [("my-notion", "conflict", incoming)]
+        result = apply_import(config, plan, force=True)
+        assert "my-notion" in result["mcpServers"]
+        assert "notion" not in result["mcpServers"]
+        assert result["mcpServers"]["my-notion"] == incoming
+
+    def test_url_alias_conflict_without_force_does_not_remove(self):
+        url = "https://mcp.notion.com/mcp"
+        existing = _entry(url)
+        incoming = _entry(url, command="new")
+        config = {"mcpServers": {"notion": existing}}
+        plan = [("my-notion", "conflict", incoming)]
+        result = apply_import(config, plan, force=False)
+        assert "notion" in result["mcpServers"]
+        assert "my-notion" not in result["mcpServers"]
 
     def test_preserves_other_keys(self):
+        e = _entry("https://new.example/mcp")
         config = {"mcpServers": {"old": {"command": "y"}}, "other": "keep"}
-        plan = [("new", "add", {"command": "x"})]
+        plan = [("new", "add", e)]
         result = apply_import(config, plan, force=False)
         assert result["other"] == "keep"
         assert "old" in result["mcpServers"]
 
     def test_does_not_mutate_original(self):
+        e = _entry("https://a.example/mcp")
         config = {"mcpServers": {}}
-        plan = [("a", "add", {"command": "x"})]
+        plan = [("a", "add", e)]
         apply_import(config, plan, force=False)
         assert "a" not in config["mcpServers"]
 
     def test_creates_mcpservers_if_missing(self):
+        e = _entry("https://a.example/mcp")
         config = {"other": "value"}
-        plan = [("a", "add", {"command": "x"})]
+        plan = [("a", "add", e)]
         result = apply_import(config, plan, force=False)
         assert "a" in result["mcpServers"]

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -89,8 +89,8 @@ def test_revert_message_empty_diff():
 class TestImportPreviewMessage:
     def test_basic_adds(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp"),
-            ("linear", "add", "https://mcp.linear.app/mcp"),
+            ("notion", "add", "https://mcp.notion.com/mcp", None),
+            ("linear", "add", "https://mcp.linear.app/mcp", None),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 2, plan, force=False
@@ -104,7 +104,7 @@ class TestImportPreviewMessage:
         assert "--write" in msg
 
     def test_singular_entry(self):
-        plan = [("notion", "add", "https://mcp.notion.com/mcp")]
+        plan = [("notion", "add", "https://mcp.notion.com/mcp", None)]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 1, plan, force=False
         )
@@ -112,8 +112,8 @@ class TestImportPreviewMessage:
 
     def test_with_identical(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp"),
-            ("linear", "identical", "https://mcp.linear.app/mcp"),
+            ("notion", "add", "https://mcp.notion.com/mcp", None),
+            ("linear", "identical", "https://mcp.linear.app/mcp", None),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 2, plan, force=False
@@ -125,8 +125,8 @@ class TestImportPreviewMessage:
 
     def test_conflict_without_force(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp"),
-            ("existing", "conflict", "https://example.com/mcp"),
+            ("notion", "add", "https://mcp.notion.com/mcp", None),
+            ("existing", "conflict", "https://example.com/mcp", None),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 2, plan, force=False
@@ -137,10 +137,22 @@ class TestImportPreviewMessage:
         assert "Error:" in msg
         assert "--write" not in msg
 
+    def test_url_alias_conflict_without_force(self):
+        plan = [
+            ("my-notion", "conflict", "https://mcp.notion.com/mcp", "notion"),
+        ]
+        msg = import_preview_message(
+            Path("/tmp/config.json"), "servers.json", 1, plan, force=False
+        )
+        assert "  ! my-notion" in msg
+        assert 'URL already under "notion"' in msg
+        assert "--force" in msg
+        assert "Error:" in msg
+
     def test_conflict_with_force(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp"),
-            ("existing", "conflict", "https://example.com/mcp"),
+            ("notion", "add", "https://mcp.notion.com/mcp", None),
+            ("existing", "conflict", "https://example.com/mcp", None),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 2, plan, force=True
@@ -151,8 +163,18 @@ class TestImportPreviewMessage:
         assert "Error:" not in msg
         assert "--write" in msg
 
+    def test_url_alias_conflict_with_force(self):
+        plan = [
+            ("my-notion", "conflict", "https://mcp.notion.com/mcp", "notion"),
+        ]
+        msg = import_preview_message(
+            Path("/tmp/config.json"), "servers.json", 1, plan, force=True
+        )
+        assert "  ~ my-notion" in msg
+        assert 'replaces "notion"' in msg
+
     def test_verbose_diff(self):
-        plan = [("notion", "add", "https://mcp.notion.com/mcp")]
+        plan = [("notion", "add", "https://mcp.notion.com/mcp", None)]
         msg = import_preview_message(
             Path("/tmp/config.json"),
             "servers.json",
@@ -168,8 +190,8 @@ class TestImportPreviewMessage:
 class TestImportWriteMessage:
     def test_basic_adds(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp"),
-            ("linear", "add", "https://mcp.linear.app/mcp"),
+            ("notion", "add", "https://mcp.notion.com/mcp", None),
+            ("linear", "add", "https://mcp.linear.app/mcp", None),
         ]
         msg = import_write_message(
             Path("/tmp/config.json"),
@@ -189,7 +211,7 @@ class TestImportWriteMessage:
         assert "Backup:" not in msg
 
     def test_with_backup(self):
-        plan = [("notion", "add", "https://mcp.notion.com/mcp")]
+        plan = [("notion", "add", "https://mcp.notion.com/mcp", None)]
         msg = import_write_message(
             Path("/tmp/config.json"),
             "servers.json",
@@ -201,8 +223,8 @@ class TestImportWriteMessage:
 
     def test_with_overwrites(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp"),
-            ("existing", "conflict", "https://example.com/mcp"),
+            ("notion", "add", "https://mcp.notion.com/mcp", None),
+            ("existing", "conflict", "https://example.com/mcp", None),
         ]
         msg = import_write_message(
             Path("/tmp/config.json"),
@@ -216,10 +238,24 @@ class TestImportWriteMessage:
         assert "Added 1" in msg
         assert "overwrote 1" in msg
 
+    def test_with_url_alias_overwrite(self):
+        plan = [
+            ("my-notion", "conflict", "https://mcp.notion.com/mcp", "notion"),
+        ]
+        msg = import_write_message(
+            Path("/tmp/config.json"),
+            "servers.json",
+            plan,
+            force=True,
+            file_existed=True,
+        )
+        assert "  ~ my-notion" in msg
+        assert 'replaced "notion"' in msg
+
     def test_with_identical(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp"),
-            ("linear", "identical", "https://mcp.linear.app/mcp"),
+            ("notion", "add", "https://mcp.notion.com/mcp", None),
+            ("linear", "identical", "https://mcp.linear.app/mcp", None),
         ]
         msg = import_write_message(
             Path("/tmp/config.json"),
@@ -231,7 +267,7 @@ class TestImportWriteMessage:
         assert "  = linear (unchanged)" in msg
 
     def test_single_entry_word(self):
-        plan = [("notion", "add", "https://mcp.notion.com/mcp")]
+        plan = [("notion", "add", "https://mcp.notion.com/mcp", None)]
         msg = import_write_message(
             Path("/tmp/config.json"),
             "servers.json",

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -89,8 +89,8 @@ def test_revert_message_empty_diff():
 class TestImportPreviewMessage:
     def test_basic_adds(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp", None),
-            ("linear", "add", "https://mcp.linear.app/mcp", None),
+            ("notion", "add", "https://mcp.notion.com/mcp", []),
+            ("linear", "add", "https://mcp.linear.app/mcp", []),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 2, plan, force=False
@@ -104,7 +104,7 @@ class TestImportPreviewMessage:
         assert "--write" in msg
 
     def test_singular_entry(self):
-        plan = [("notion", "add", "https://mcp.notion.com/mcp", None)]
+        plan = [("notion", "add", "https://mcp.notion.com/mcp", [])]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 1, plan, force=False
         )
@@ -112,8 +112,8 @@ class TestImportPreviewMessage:
 
     def test_with_identical(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp", None),
-            ("linear", "identical", "https://mcp.linear.app/mcp", None),
+            ("notion", "add", "https://mcp.notion.com/mcp", []),
+            ("linear", "identical", "https://mcp.linear.app/mcp", []),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 2, plan, force=False
@@ -125,8 +125,8 @@ class TestImportPreviewMessage:
 
     def test_conflict_without_force(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp", None),
-            ("existing", "conflict", "https://example.com/mcp", None),
+            ("notion", "add", "https://mcp.notion.com/mcp", []),
+            ("existing", "conflict", "https://example.com/mcp", []),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 2, plan, force=False
@@ -139,7 +139,7 @@ class TestImportPreviewMessage:
 
     def test_url_alias_conflict_without_force(self):
         plan = [
-            ("my-notion", "conflict", "https://mcp.notion.com/mcp", "notion"),
+            ("my-notion", "conflict", "https://mcp.notion.com/mcp", ["notion"]),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 1, plan, force=False
@@ -149,10 +149,22 @@ class TestImportPreviewMessage:
         assert "--force" in msg
         assert "Error:" in msg
 
+    def test_same_name_conflict_also_drops_aliased_url_without_force(self):
+        """Same-name conflict whose URL is already used by another entry also
+        warns about the aliased entry that would be removed."""
+        plan = [
+            ("notion", "conflict", "https://mcp.notion.com/mcp", ["other"]),
+        ]
+        msg = import_preview_message(
+            Path("/tmp/config.json"), "servers.json", 1, plan, force=False
+        )
+        assert "  ! notion" in msg
+        assert 'URL already under "other"' in msg
+
     def test_conflict_with_force(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp", None),
-            ("existing", "conflict", "https://example.com/mcp", None),
+            ("notion", "add", "https://mcp.notion.com/mcp", []),
+            ("existing", "conflict", "https://example.com/mcp", []),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 2, plan, force=True
@@ -165,7 +177,7 @@ class TestImportPreviewMessage:
 
     def test_url_alias_conflict_with_force(self):
         plan = [
-            ("my-notion", "conflict", "https://mcp.notion.com/mcp", "notion"),
+            ("my-notion", "conflict", "https://mcp.notion.com/mcp", ["notion"]),
         ]
         msg = import_preview_message(
             Path("/tmp/config.json"), "servers.json", 1, plan, force=True
@@ -173,8 +185,18 @@ class TestImportPreviewMessage:
         assert "  ~ my-notion" in msg
         assert 'replaces "notion"' in msg
 
+    def test_same_name_conflict_with_force_lists_all_removed_aliases(self):
+        plan = [
+            ("notion", "conflict", "https://mcp.notion.com/mcp", ["alt1", "alt2"]),
+        ]
+        msg = import_preview_message(
+            Path("/tmp/config.json"), "servers.json", 1, plan, force=True
+        )
+        assert "  ~ notion" in msg
+        assert 'replaces "alt1", "alt2"' in msg
+
     def test_verbose_diff(self):
-        plan = [("notion", "add", "https://mcp.notion.com/mcp", None)]
+        plan = [("notion", "add", "https://mcp.notion.com/mcp", [])]
         msg = import_preview_message(
             Path("/tmp/config.json"),
             "servers.json",
@@ -190,8 +212,8 @@ class TestImportPreviewMessage:
 class TestImportWriteMessage:
     def test_basic_adds(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp", None),
-            ("linear", "add", "https://mcp.linear.app/mcp", None),
+            ("notion", "add", "https://mcp.notion.com/mcp", []),
+            ("linear", "add", "https://mcp.linear.app/mcp", []),
         ]
         msg = import_write_message(
             Path("/tmp/config.json"),
@@ -211,7 +233,7 @@ class TestImportWriteMessage:
         assert "Backup:" not in msg
 
     def test_with_backup(self):
-        plan = [("notion", "add", "https://mcp.notion.com/mcp", None)]
+        plan = [("notion", "add", "https://mcp.notion.com/mcp", [])]
         msg = import_write_message(
             Path("/tmp/config.json"),
             "servers.json",
@@ -223,8 +245,8 @@ class TestImportWriteMessage:
 
     def test_with_overwrites(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp", None),
-            ("existing", "conflict", "https://example.com/mcp", None),
+            ("notion", "add", "https://mcp.notion.com/mcp", []),
+            ("existing", "conflict", "https://example.com/mcp", []),
         ]
         msg = import_write_message(
             Path("/tmp/config.json"),
@@ -240,7 +262,7 @@ class TestImportWriteMessage:
 
     def test_with_url_alias_overwrite(self):
         plan = [
-            ("my-notion", "conflict", "https://mcp.notion.com/mcp", "notion"),
+            ("my-notion", "conflict", "https://mcp.notion.com/mcp", ["notion"]),
         ]
         msg = import_write_message(
             Path("/tmp/config.json"),
@@ -252,10 +274,24 @@ class TestImportWriteMessage:
         assert "  ~ my-notion" in msg
         assert 'replaced "notion"' in msg
 
+    def test_same_name_conflict_reports_removed_alias(self):
+        plan = [
+            ("notion", "conflict", "https://mcp.notion.com/mcp", ["other"]),
+        ]
+        msg = import_write_message(
+            Path("/tmp/config.json"),
+            "servers.json",
+            plan,
+            force=True,
+            file_existed=True,
+        )
+        assert "  ~ notion" in msg
+        assert 'replaced "other"' in msg
+
     def test_with_identical(self):
         plan = [
-            ("notion", "add", "https://mcp.notion.com/mcp", None),
-            ("linear", "identical", "https://mcp.linear.app/mcp", None),
+            ("notion", "add", "https://mcp.notion.com/mcp", []),
+            ("linear", "identical", "https://mcp.linear.app/mcp", []),
         ]
         msg = import_write_message(
             Path("/tmp/config.json"),
@@ -267,7 +303,7 @@ class TestImportWriteMessage:
         assert "  = linear (unchanged)" in msg
 
     def test_single_entry_word(self):
-        plan = [("notion", "add", "https://mcp.notion.com/mcp", None)]
+        plan = [("notion", "add", "https://mcp.notion.com/mcp", [])]
         msg = import_write_message(
             Path("/tmp/config.json"),
             "servers.json",


### PR DESCRIPTION
## Summary

Aligns `cdcasasagi import` with `add`'s URL uniqueness guarantee (closes #36).
Previously, importing `{"url": existing_url, "name": "my-notion"}` against a
config that already held that URL under `notion` was classified as `"add"`,
producing two entries with the same URL.

- `plan_import` now takes `(name, url, entry)` tuples and classifies
  URL-aliased entries as `"conflict"`, matching the same-name case.
- `apply_import` on a conflict with `--force` removes any existing entries
  with the same URL (via `find_entry_names_by_url`) before writing the new
  one — mirroring `merge_entry`.
- Preview/write messages now distinguish URL-alias conflicts
  (`URL already under "notion"` / `replaces "notion"`) from plain same-name
  conflicts.
- All-or-nothing semantics preserved: a single URL-alias conflict in the
  input blocks the whole write without `--force`.

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` (180 passed)
- [x] `cd e2e && CLAUDE_DESKTOP_CONFIG=/tmp/test-claude-config.json uv run gauge run specs` (17 scenarios, including 2 new ones)

Closes #36