### PR TITLE
list: show cdcasasagi-managed MCP servers as `name : url`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ cdcasasagi import - --write
 # (Ctrl+D / Ctrl+Z also works)
 ```
 
+### list
+
+Show cdcasasagi-managed MCP servers in the config:
+
+```
+cdcasasagi list
+```
+
+Output is `name : url`, one entry per line, sorted by name. Only entries whose `command` is `mcp-proxy` (or `mcp-proxy.exe` on Windows) are shown.
+
 ### validate-import
 
 Validate a JSONL file's schema without importing. This command never writes any files.

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -53,6 +53,20 @@ def doctor() -> None:
         raise typer.Exit(code=1)
 
 
+@app.command(name="list")
+def list_cmd() -> None:
+    """List cdcasasagi-managed MCP servers as 'name : url'."""
+    cfg_path = desktop_config.config_path()
+    try:
+        config = desktop_config.load_config(cfg_path)
+    except desktop_config.ConfigError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(code=1)
+
+    servers = desktop_config.list_mcp_proxy_entries(config)
+    typer.echo(output.list_message(cfg_path, servers))
+
+
 def _validate_url(url: str) -> None:
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -96,13 +96,10 @@ def list_mcp_proxy_entries(config: dict[str, Any]) -> list[tuple[str, str]]:
     result: list[tuple[str, str]] = []
     for name, entry in config.get("mcpServers", {}).items():
         cmd = entry.get("command", "")
-        if not isinstance(cmd, str) or Path(cmd).name not in {
-            "mcp-proxy",
-            "mcp-proxy.exe",
-        }:
+        if Path(cmd).name not in {"mcp-proxy", "mcp-proxy.exe"}:
             continue
         args = entry.get("args", [])
-        if not isinstance(args, list) or len(args) < 3 or args[0] != "--transport":
+        if len(args) < 3 or args[0] != "--transport":
             continue
         result.append((name, args[-1]))
     result.sort(key=lambda x: x[0])

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -99,7 +99,7 @@ def list_mcp_proxy_entries(config: dict[str, Any]) -> list[tuple[str, str]]:
         if Path(cmd).name not in {"mcp-proxy", "mcp-proxy.exe"}:
             continue
         args = entry.get("args", [])
-        if len(args) < 3 or args[0] != "--transport":
+        if not isinstance(args, list) or len(args) < 3 or args[0] != "--transport":
             continue
         result.append((name, args[-1]))
     result.sort(key=lambda x: x[0])

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -96,7 +96,10 @@ def list_mcp_proxy_entries(config: dict[str, Any]) -> list[tuple[str, str]]:
     result: list[tuple[str, str]] = []
     for name, entry in config.get("mcpServers", {}).items():
         cmd = entry.get("command", "")
-        if Path(cmd).name not in {"mcp-proxy", "mcp-proxy.exe"}:
+        if not isinstance(cmd, str) or Path(cmd).name not in {
+            "mcp-proxy",
+            "mcp-proxy.exe",
+        }:
             continue
         args = entry.get("args", [])
         if not isinstance(args, list) or len(args) < 3 or args[0] != "--transport":

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -88,6 +88,24 @@ def find_entry_names_by_url(config: dict[str, Any], url: str) -> list[str]:
     return names
 
 
+def list_mcp_proxy_entries(config: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return ``(name, url)`` for every entry whose command basename is mcp-proxy.
+
+    Entries with unexpected ``args`` shape are skipped.
+    """
+    result: list[tuple[str, str]] = []
+    for name, entry in config.get("mcpServers", {}).items():
+        cmd = entry.get("command", "")
+        if Path(cmd).name not in {"mcp-proxy", "mcp-proxy.exe"}:
+            continue
+        args = entry.get("args", [])
+        if len(args) < 3 or args[0] != "--transport":
+            continue
+        result.append((name, args[-1]))
+    result.sort(key=lambda x: x[0])
+    return result
+
+
 def build_entry(mcp_proxy_path: Path, transport: str, url: str) -> dict[str, Any]:
     return {
         "command": str(mcp_proxy_path),

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -259,6 +259,16 @@ def validate_error_message(
     return "\n".join(lines)
 
 
+def list_message(config_path: Path, servers: list[tuple[str, str]]) -> str:
+    if not servers:
+        return f"No mcp-proxy MCP servers configured.\nTarget: {config_path}"
+    max_name = max(len(n) for n, _ in servers)
+    lines = [f"Target: {config_path}", ""]
+    for name, url in servers:
+        lines.append(f"  {name.ljust(max_name)} : {url}")
+    return "\n".join(lines)
+
+
 def doctor_message(results: list[tuple[str, bool, str]]) -> str:
     lines: list[str] = []
     for label, passed, detail in results:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,6 +90,128 @@ class TestDoctor:
         assert "Config directory:" in result.output
 
 
+class TestList:
+    def test_lists_entries_alphabetically(self, config_env):
+        config_file, fake_proxy = config_env
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": {
+                            "command": str(fake_proxy),
+                            "args": [
+                                "--transport",
+                                "streamablehttp",
+                                "https://mcp.notion.com/mcp",
+                            ],
+                        },
+                        "developers": {
+                            "command": str(fake_proxy),
+                            "args": [
+                                "--transport",
+                                "streamablehttp",
+                                "https://developers.openai.com/mcp",
+                            ],
+                        },
+                    }
+                }
+            )
+        )
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "developers" in result.output
+        assert "notion" in result.output
+        assert "https://mcp.notion.com/mcp" in result.output
+        assert "https://developers.openai.com/mcp" in result.output
+        # alphabetical: developers before notion
+        assert result.output.index("developers") < result.output.index("notion")
+        assert f"Target: {config_file}" in result.output
+
+    def test_empty_servers(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text('{"mcpServers": {}}')
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "No mcp-proxy MCP servers configured." in result.output
+        assert f"Target: {config_file}" in result.output
+
+    def test_no_config_file(self, config_env):
+        config_file, _ = config_env
+        assert not config_file.exists()
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "No mcp-proxy MCP servers configured." in result.output
+
+    def test_filters_non_mcp_proxy_entries(self, config_env):
+        config_file, fake_proxy = config_env
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": {
+                            "command": str(fake_proxy),
+                            "args": [
+                                "--transport",
+                                "streamablehttp",
+                                "https://mcp.notion.com/mcp",
+                            ],
+                        },
+                        "other": {
+                            "command": "/usr/bin/some-other-tool",
+                            "args": ["--whatever"],
+                        },
+                    }
+                }
+            )
+        )
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "notion" in result.output
+        assert "https://mcp.notion.com/mcp" in result.output
+        assert "other" not in result.output
+        assert "some-other-tool" not in result.output
+
+    def test_skips_malformed_args(self, config_env):
+        config_file, fake_proxy = config_env
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "broken": {
+                            "command": str(fake_proxy),
+                            "args": [],
+                        },
+                        "wrong-flag": {
+                            "command": str(fake_proxy),
+                            "args": ["--other", "x", "https://example.com/mcp"],
+                        },
+                        "ok": {
+                            "command": str(fake_proxy),
+                            "args": [
+                                "--transport",
+                                "streamablehttp",
+                                "https://example.com/mcp",
+                            ],
+                        },
+                    }
+                }
+            )
+        )
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "ok" in result.output
+        assert "https://example.com/mcp" in result.output
+        assert "broken" not in result.output
+        assert "wrong-flag" not in result.output
+
+    def test_corrupt_config(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text("not json at all")
+        result = runner.invoke(app, ["list"])
+        assert result.exit_code == 1
+        assert "Failed to parse JSON config file" in result.output
+
+
 class TestAddPreview:
     def test_preview_derived_name(self, config_env):
         config_file, _ = config_env

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -399,25 +399,6 @@ class TestListMcpProxyEntries:
         }
         assert list_mcp_proxy_entries(config) == [("notion", "https://n.example/mcp")]
 
-    def test_skips_non_string_command(self):
-        config = {
-            "mcpServers": {
-                "null-cmd": {
-                    "command": None,
-                    "args": ["--transport", "streamablehttp", "https://x.example/mcp"],
-                },
-                "dict-cmd": {
-                    "command": {"path": "/usr/bin/mcp-proxy"},
-                    "args": ["--transport", "streamablehttp", "https://y.example/mcp"],
-                },
-                "ok": {
-                    "command": "/usr/bin/mcp-proxy",
-                    "args": ["--transport", "streamablehttp", "https://z.example/mcp"],
-                },
-            }
-        }
-        assert list_mcp_proxy_entries(config) == [("ok", "https://z.example/mcp")]
-
     def test_skips_malformed_args(self):
         config = {
             "mcpServers": {
@@ -428,14 +409,6 @@ class TestListMcpProxyEntries:
                 "wrong-flag": {
                     "command": "/usr/bin/mcp-proxy",
                     "args": ["--other", "x", "https://example.com/mcp"],
-                },
-                "null-args": {
-                    "command": "/usr/bin/mcp-proxy",
-                    "args": None,
-                },
-                "dict-args": {
-                    "command": "/usr/bin/mcp-proxy",
-                    "args": {"transport": "streamablehttp"},
                 },
                 "ok": {
                     "command": "/usr/bin/mcp-proxy",

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -410,6 +410,14 @@ class TestListMcpProxyEntries:
                     "command": "/usr/bin/mcp-proxy",
                     "args": ["--other", "x", "https://example.com/mcp"],
                 },
+                "null-args": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": None,
+                },
+                "dict-args": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": {"transport": "streamablehttp"},
+                },
                 "ok": {
                     "command": "/usr/bin/mcp-proxy",
                     "args": [

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -399,6 +399,25 @@ class TestListMcpProxyEntries:
         }
         assert list_mcp_proxy_entries(config) == [("notion", "https://n.example/mcp")]
 
+    def test_skips_non_string_command(self):
+        config = {
+            "mcpServers": {
+                "null-cmd": {
+                    "command": None,
+                    "args": ["--transport", "streamablehttp", "https://x.example/mcp"],
+                },
+                "dict-cmd": {
+                    "command": {"path": "/usr/bin/mcp-proxy"},
+                    "args": ["--transport", "streamablehttp", "https://y.example/mcp"],
+                },
+                "ok": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": ["--transport", "streamablehttp", "https://z.example/mcp"],
+                },
+            }
+        }
+        assert list_mcp_proxy_entries(config) == [("ok", "https://z.example/mcp")]
+
     def test_skips_malformed_args(self):
         config = {
             "mcpServers": {

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -12,6 +12,7 @@ from cdcasasagi.desktop_config import (
     backup_path,
     build_entry,
     config_path,
+    list_mcp_proxy_entries,
     load_backup,
     load_config,
     merge_entry,
@@ -353,3 +354,90 @@ class TestApplyImport:
         plan = [("a", "add", e)]
         result = apply_import(config, plan, force=False)
         assert "a" in result["mcpServers"]
+
+
+class TestListMcpProxyEntries:
+    def test_empty_config(self):
+        assert list_mcp_proxy_entries({}) == []
+        assert list_mcp_proxy_entries({"mcpServers": {}}) == []
+
+    def test_basename_match_unix(self):
+        config = {
+            "mcpServers": {
+                "notion": {
+                    "command": "/Users/me/.local/bin/mcp-proxy",
+                    "args": ["--transport", "streamablehttp", "https://n.example/mcp"],
+                }
+            }
+        }
+        assert list_mcp_proxy_entries(config) == [("notion", "https://n.example/mcp")]
+
+    def test_basename_match_exe(self):
+        # `.exe` suffix is recognized so Windows configs round-trip.
+        config = {
+            "mcpServers": {
+                "notion": {
+                    "command": "/some/path/mcp-proxy.exe",
+                    "args": ["--transport", "streamablehttp", "https://n.example/mcp"],
+                }
+            }
+        }
+        assert list_mcp_proxy_entries(config) == [("notion", "https://n.example/mcp")]
+
+    def test_filters_non_mcp_proxy(self):
+        config = {
+            "mcpServers": {
+                "notion": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": ["--transport", "streamablehttp", "https://n.example/mcp"],
+                },
+                "other": {
+                    "command": "/usr/bin/some-other-tool",
+                    "args": ["--whatever"],
+                },
+            }
+        }
+        assert list_mcp_proxy_entries(config) == [("notion", "https://n.example/mcp")]
+
+    def test_skips_malformed_args(self):
+        config = {
+            "mcpServers": {
+                "broken": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": [],
+                },
+                "wrong-flag": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": ["--other", "x", "https://example.com/mcp"],
+                },
+                "ok": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": [
+                        "--transport",
+                        "streamablehttp",
+                        "https://example.com/mcp",
+                    ],
+                },
+            }
+        }
+        assert list_mcp_proxy_entries(config) == [("ok", "https://example.com/mcp")]
+
+    def test_sorted_alphabetically(self):
+        config = {
+            "mcpServers": {
+                "zoo": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": ["--transport", "streamablehttp", "https://z.example/mcp"],
+                },
+                "alpha": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": ["--transport", "streamablehttp", "https://a.example/mcp"],
+                },
+                "middle": {
+                    "command": "/usr/bin/mcp-proxy",
+                    "args": ["--transport", "streamablehttp", "https://m.example/mcp"],
+                },
+            }
+        }
+        result = list_mcp_proxy_entries(config)
+        assert [name for name, _ in result] == ["alpha", "middle", "zoo"]

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -5,6 +5,7 @@ from cdcasasagi.output import (
     format_diff,
     import_preview_message,
     import_write_message,
+    list_message,
     preview_message,
     revert_message,
     write_message,
@@ -362,3 +363,46 @@ class TestDoctorMessage:
         ]
         msg = doctor_message(results)
         assert msg.isascii()
+
+
+class TestListMessage:
+    def test_empty(self):
+        msg = list_message(Path("/tmp/config.json"), [])
+        assert "No mcp-proxy MCP servers configured." in msg
+        assert "Target: /tmp/config.json" in msg
+
+    def test_formats_entries(self):
+        servers = [
+            ("notion", "https://mcp.notion.com/mcp"),
+            ("openai-developer-docs", "https://developers.openai.com/mcp"),
+        ]
+        msg = list_message(Path("/tmp/config.json"), servers)
+        assert "Target: /tmp/config.json" in msg
+        assert "notion" in msg
+        assert "https://mcp.notion.com/mcp" in msg
+        assert "openai-developer-docs" in msg
+        assert "https://developers.openai.com/mcp" in msg
+
+    def test_aligns_names(self):
+        servers = [
+            ("a", "https://a.example/mcp"),
+            ("longer-name", "https://b.example/mcp"),
+        ]
+        msg = list_message(Path("/tmp/config.json"), servers)
+        # Both URLs should appear at the same column thanks to ljust padding.
+        lines = [line for line in msg.splitlines() if " : " in line]
+        assert len(lines) == 2
+        url_columns = {line.index(" : ") for line in lines}
+        assert len(url_columns) == 1
+
+    def test_uses_colon_separator(self):
+        servers = [("notion", "https://mcp.notion.com/mcp")]
+        msg = list_message(Path("/tmp/config.json"), servers)
+        assert "notion : https://mcp.notion.com/mcp" in msg
+
+    def test_ascii_only(self):
+        servers = [("notion", "https://mcp.notion.com/mcp")]
+        msg = list_message(Path("/tmp/config.json"), servers)
+        assert msg.isascii()
+        empty = list_message(Path("/tmp/config.json"), [])
+        assert empty.isascii()


### PR DESCRIPTION
Closes #38.

## Summary

Adds a read-only `cdcasasagi list` command that prints the cdcasasagi-managed MCP server entries in the current Claude Desktop config, one per line as `name : url` (sorted alphabetically by name).

```
$ cdcasasagi list
Target: /Users/you/Library/Application Support/Claude/claude_desktop_config.json

  notion                : https://mcp.notion.com/mcp
  openai-developer-docs : https://developers.openai.com/mcp
```

Empty case:

```
$ cdcasasagi list
No mcp-proxy MCP servers configured.
Target: /Users/you/Library/Application Support/Claude/claude_desktop_config.json
```

## Design notes

- **Filter rule** — basename match: `Path(entry["command"]).name in {"mcp-proxy", "mcp-proxy.exe"}`. Strict matching against `mcp_proxy.resolve_path()` would (a) make this read-only command hard-fail when mcp-proxy is missing and (b) hide entries written by a previous cdcasasagi install in a different venv.
- **Args robustness** — entries with malformed `args` (fewer than 3 elements, or `args[0] != "--transport"`) are skipped silently. URL is taken from `args[-1]`, consistent with `find_entry_names_by_url`.
- **No `--write`** — the command never mutates the config; same shape as `doctor` / `validate-import`.
- **Layered like the rest** — config-shape logic lives in `desktop_config.list_mcp_proxy_entries`; formatting in `output.list_message`; the CLI handler is a thin glue function.

## Files changed

- `src/cdcasasagi/cli.py` — new `list_cmd` (registered as `name="list"` to avoid the Python builtin clash)
- `src/cdcasasagi/desktop_config.py` — new `list_mcp_proxy_entries()`
- `src/cdcasasagi/output.py` — new `list_message()`
- `tests/test_cli.py`, `tests/test_desktop_config.py`, `tests/test_output.py` — coverage for happy path, empty config, missing config file, non-mcp-proxy filtering, malformed-args skipping, corrupt-config error, alignment, ASCII-only output
- `README.md` — `### list` subsection

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` — 202 passed
- [x] Manual smoke: empty case, populated case, `--help`
