### PR TITLE
delete: remove an mcpServers entry by URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ The written entry looks like this:
 }
 ```
 
+### delete
+
+Remove an entry from the Claude Desktop config by name:
+
+```
+cdcasasagi delete notion
+```
+
+This shows a unified diff of the proposed removal. Pass `--write` to apply:
+
+```
+cdcasasagi delete notion --write
+```
+
 ### import
 
 Add multiple entries at once from a JSONL file:

--- a/README.md
+++ b/README.md
@@ -57,17 +57,19 @@ The written entry looks like this:
 
 ### delete
 
-Remove an entry from the Claude Desktop config by name:
+Remove an entry from the Claude Desktop config by URL:
 
 ```
-cdcasasagi delete notion
+cdcasasagi delete https://mcp.notion.com/mcp
 ```
 
 This shows a unified diff of the proposed removal. Pass `--write` to apply:
 
 ```
-cdcasasagi delete notion --write
+cdcasasagi delete https://mcp.notion.com/mcp --write
 ```
+
+Only entries added by cdcasasagi (whose `command` is `mcp-proxy`) are removed. Hand-added entries that happen to share a URL are left alone.
 
 ### import
 

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -133,6 +133,33 @@ def add(
 
 
 @app.command()
+def delete(
+    name: str = typer.Argument(..., help="Name of the mcpServers entry to remove"),
+    write: bool = typer.Option(False, help="Actually write to the file"),
+) -> None:
+    cfg_path = desktop_config.config_path()
+
+    try:
+        current_config = desktop_config.load_config(cfg_path)
+    except desktop_config.ConfigError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        updated = desktop_config.remove_entry(current_config, name)
+    except desktop_config.EntryNotFoundError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(code=1)
+
+    if not write:
+        diff_text = output.format_diff(current_config, updated)
+        typer.echo(output.delete_preview_message(name, cfg_path, diff_text))
+    else:
+        desktop_config.write_config(cfg_path, updated)
+        typer.echo(output.delete_write_message(name, cfg_path))
+
+
+@app.command()
 def revert() -> None:
     cfg_path = desktop_config.config_path()
 

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -134,7 +134,7 @@ def add(
 
 @app.command()
 def delete(
-    name: str = typer.Argument(..., help="Name of the mcpServers entry to remove"),
+    url: str = typer.Argument(..., help="URL of the mcpServers entry to remove"),
     write: bool = typer.Option(False, help="Actually write to the file"),
 ) -> None:
     cfg_path = desktop_config.config_path()
@@ -146,17 +146,17 @@ def delete(
         raise typer.Exit(code=1)
 
     try:
-        updated = desktop_config.remove_entry(current_config, name)
+        updated, removed = desktop_config.remove_entries_by_url(current_config, url)
     except desktop_config.EntryNotFoundError as e:
         typer.echo(str(e), err=True)
         raise typer.Exit(code=1)
 
     if not write:
         diff_text = output.format_diff(current_config, updated)
-        typer.echo(output.delete_preview_message(name, cfg_path, diff_text))
+        typer.echo(output.delete_preview_message(url, removed, cfg_path, diff_text))
     else:
         desktop_config.write_config(cfg_path, updated)
-        typer.echo(output.delete_write_message(name, cfg_path))
+        typer.echo(output.delete_write_message(url, removed, cfg_path))
 
 
 @app.command()

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -146,13 +146,35 @@ def merge_entry(
     return config
 
 
-def remove_entry(config: dict[str, Any], name: str) -> dict[str, Any]:
+def remove_entries_by_url(
+    config: dict[str, Any], url: str
+) -> tuple[dict[str, Any], list[str]]:
+    """Remove every cdcasasagi-managed entry whose URL matches.
+
+    An entry is considered managed when ``command`` basename is ``mcp-proxy``
+    (or ``mcp-proxy.exe``) and ``args`` starts with ``--transport`` followed
+    by a transport value and the URL -- the same shape written by ``add``
+    and required by ``list_mcp_proxy_entries``. Hand-edited entries that
+    happen to end in *url* are left alone. Raises :class:`EntryNotFoundError`
+    when nothing matches. Returns ``(updated_config, removed_names)``.
+    """
     config = json.loads(json.dumps(config))  # deep copy
     servers = config.setdefault("mcpServers", {})
-    if name not in servers:
-        raise EntryNotFoundError(f'"{name}" not found in mcpServers')
-    del servers[name]
-    return config
+    names: list[str] = []
+    for name, entry in servers.items():
+        cmd = entry.get("command", "")
+        if Path(cmd).name not in {"mcp-proxy", "mcp-proxy.exe"}:
+            continue
+        args = entry.get("args", [])
+        if len(args) < 3 or args[0] != "--transport":
+            continue
+        if args[-1] == url:
+            names.append(name)
+    if not names:
+        raise EntryNotFoundError(f"No cdcasasagi-managed entry found for URL: {url}")
+    for name in names:
+        del servers[name]
+    return config, names
 
 
 def plan_import(

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -17,6 +17,10 @@ class EntryExistsError(Exception):
     pass
 
 
+class EntryNotFoundError(Exception):
+    pass
+
+
 class BackupNotFoundError(Exception):
     pass
 
@@ -139,6 +143,15 @@ def merge_entry(
         raise EntryExistsError(f'"{name}" already exists. Use --force to overwrite')
 
     config["mcpServers"][name] = entry
+    return config
+
+
+def remove_entry(config: dict[str, Any], name: str) -> dict[str, Any]:
+    config = json.loads(json.dumps(config))  # deep copy
+    servers = config.setdefault("mcpServers", {})
+    if name not in servers:
+        raise EntryNotFoundError(f'"{name}" not found in mcpServers')
+    del servers[name]
     return config
 
 

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -77,25 +77,29 @@ def revert_message(
     return "\n".join(lines)
 
 
-def delete_preview_message(name: str, config_path: Path, diff_text: str) -> str:
+def delete_preview_message(
+    url: str, removed_names: list[str], config_path: Path, diff_text: str
+) -> str:
+    names = _format_replaces(removed_names)
     lines = [
         f"Target: {config_path}",
         "",
         diff_text.rstrip(),
         "",
-        f'Will remove "{name}".',
+        f"Will remove {names} ({url}).",
         "This is a preview. Re-run with --write to apply.",
     ]
     return "\n".join(lines)
 
 
-def delete_write_message(name: str, config_path: Path) -> str:
+def delete_write_message(url: str, removed_names: list[str], config_path: Path) -> str:
     backup = config_path.with_suffix(config_path.suffix + ".bak")
+    names = _format_replaces(removed_names)
     lines = [
         f"Backup: {backup}",
         f"Wrote:  {config_path}",
         "",
-        f'Removed "{name}". Restart Claude Desktop to take effect.',
+        f"Removed {names} ({url}). Restart Claude Desktop to take effect.",
     ]
     return "\n".join(lines)
 

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -77,6 +77,29 @@ def revert_message(
     return "\n".join(lines)
 
 
+def delete_preview_message(name: str, config_path: Path, diff_text: str) -> str:
+    lines = [
+        f"Target: {config_path}",
+        "",
+        diff_text.rstrip(),
+        "",
+        f'Will remove "{name}".',
+        "This is a preview. Re-run with --write to apply.",
+    ]
+    return "\n".join(lines)
+
+
+def delete_write_message(name: str, config_path: Path) -> str:
+    backup = config_path.with_suffix(config_path.suffix + ".bak")
+    lines = [
+        f"Backup: {backup}",
+        f"Wrote:  {config_path}",
+        "",
+        f'Removed "{name}". Restart Claude Desktop to take effect.',
+    ]
+    return "\n".join(lines)
+
+
 def write_message(
     name: str,
     name_was_derived: bool,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -436,134 +436,122 @@ class TestRevert:
 
 
 class TestDelete:
+    @staticmethod
+    def _managed(command, url):
+        return {
+            "command": str(command),
+            "args": ["--transport", "streamablehttp", url],
+        }
+
     def test_preview_shows_diff(self, config_env):
         config_file, fake_proxy = config_env
+        url = "https://mcp.notion.com/mcp"
         config_file.write_text(
-            json.dumps(
-                {
-                    "mcpServers": {
-                        "notion": {
-                            "command": str(fake_proxy),
-                            "args": [
-                                "--transport",
-                                "streamablehttp",
-                                "https://mcp.notion.com/mcp",
-                            ],
-                        }
-                    }
-                }
-            )
+            json.dumps({"mcpServers": {"notion": self._managed(fake_proxy, url)}})
         )
         before = config_file.read_text()
-        result = runner.invoke(app, ["delete", "notion"])
+        result = runner.invoke(app, ["delete", url])
         assert result.exit_code == 0
         assert f"Target: {config_file}" in result.output
         assert "--- current" in result.output
         assert "+++ proposed" in result.output
         assert '-    "notion"' in result.output
-        assert 'Will remove "notion".' in result.output
+        assert f'Will remove "notion" ({url}).' in result.output
         assert "--write" in result.output
         assert config_file.read_text() == before
 
     def test_write_removes_entry(self, config_env):
         config_file, fake_proxy = config_env
+        notion_url = "https://mcp.notion.com/mcp"
+        linear_url = "https://mcp.linear.app/mcp"
         config_file.write_text(
             json.dumps(
                 {
                     "mcpServers": {
-                        "notion": {
-                            "command": str(fake_proxy),
-                            "args": [
-                                "--transport",
-                                "streamablehttp",
-                                "https://mcp.notion.com/mcp",
-                            ],
-                        },
-                        "linear": {
-                            "command": str(fake_proxy),
-                            "args": [
-                                "--transport",
-                                "streamablehttp",
-                                "https://mcp.linear.app/mcp",
-                            ],
-                        },
+                        "notion": self._managed(fake_proxy, notion_url),
+                        "linear": self._managed(fake_proxy, linear_url),
                     },
                     "other": "keep",
                 }
             )
         )
-        result = runner.invoke(app, ["delete", "notion", "--write"])
+        result = runner.invoke(app, ["delete", notion_url, "--write"])
         assert result.exit_code == 0
         data = json.loads(config_file.read_text())
         assert "notion" not in data["mcpServers"]
         assert "linear" in data["mcpServers"]
         assert data["other"] == "keep"
         assert config_file.with_suffix(".json.bak").exists()
-        assert 'Removed "notion".' in result.output
+        assert f'Removed "notion" ({notion_url}).' in result.output
         assert "Restart Claude Desktop" in result.output
 
-    def test_entry_not_found(self, config_env):
+    def test_url_not_found(self, config_env):
         config_file, fake_proxy = config_env
         config_file.write_text(
             json.dumps(
                 {
                     "mcpServers": {
-                        "notion": {
-                            "command": str(fake_proxy),
-                            "args": [
-                                "--transport",
-                                "streamablehttp",
-                                "https://mcp.notion.com/mcp",
-                            ],
+                        "notion": self._managed(
+                            fake_proxy, "https://mcp.notion.com/mcp"
+                        )
+                    }
+                }
+            )
+        )
+        before = config_file.read_text()
+        result = runner.invoke(app, ["delete", "https://missing.example.com/mcp"])
+        assert result.exit_code == 1
+        assert "No cdcasasagi-managed entry found" in result.output
+        assert "https://missing.example.com/mcp" in result.output
+        assert config_file.read_text() == before
+
+    def test_no_config_file(self, config_env):
+        config_file, _ = config_env
+        assert not config_file.exists()
+        result = runner.invoke(app, ["delete", "https://mcp.notion.com/mcp"])
+        assert result.exit_code == 1
+        assert "No cdcasasagi-managed entry found" in result.output
+
+    def test_corrupt_config(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text("not json at all")
+        result = runner.invoke(app, ["delete", "https://mcp.notion.com/mcp"])
+        assert result.exit_code == 1
+        assert "Failed to parse JSON config file" in result.output
+
+    def test_ignores_non_managed_entry_with_matching_url(self, config_env):
+        config_file, _ = config_env
+        url = "https://mcp.notion.com/mcp"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "custom": {
+                            "command": "/usr/bin/some-other-tool",
+                            "args": ["--transport", "streamablehttp", url],
                         }
                     }
                 }
             )
         )
         before = config_file.read_text()
-        result = runner.invoke(app, ["delete", "foo"])
+        result = runner.invoke(app, ["delete", url, "--write"])
         assert result.exit_code == 1
-        assert '"foo" not found' in result.output
+        assert "No cdcasasagi-managed entry found" in result.output
         assert config_file.read_text() == before
-
-    def test_no_config_file(self, config_env):
-        config_file, _ = config_env
-        assert not config_file.exists()
-        result = runner.invoke(app, ["delete", "notion"])
-        assert result.exit_code == 1
-        assert '"notion" not found' in result.output
-
-    def test_corrupt_config(self, config_env):
-        config_file, _ = config_env
-        config_file.write_text("not json at all")
-        result = runner.invoke(app, ["delete", "notion"])
-        assert result.exit_code == 1
-        assert "Failed to parse JSON config file" in result.output
 
     def test_delete_then_revert_restores(self, config_env):
         config_file, fake_proxy = config_env
+        notion_url = "https://mcp.notion.com/mcp"
+        linear_url = "https://mcp.linear.app/mcp"
         original = {
             "mcpServers": {
-                "notion": {
-                    "command": str(fake_proxy),
-                    "args": [
-                        "--transport",
-                        "streamablehttp",
-                        "https://mcp.notion.com/mcp",
-                    ],
-                },
-                "linear": {
-                    "command": str(fake_proxy),
-                    "args": [
-                        "--transport",
-                        "streamablehttp",
-                        "https://mcp.linear.app/mcp",
-                    ],
-                },
+                "notion": self._managed(fake_proxy, notion_url),
+                "linear": self._managed(fake_proxy, linear_url),
             }
         }
         config_file.write_text(json.dumps(original))
-        result = runner.invoke(app, ["delete", "notion", "--write"])
+        result = runner.invoke(app, ["delete", notion_url, "--write"])
         assert result.exit_code == 0
         result = runner.invoke(app, ["revert"])
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -435,6 +435,143 @@ class TestRevert:
         assert "Removed:" in result.output
 
 
+class TestDelete:
+    def test_preview_shows_diff(self, config_env):
+        config_file, fake_proxy = config_env
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": {
+                            "command": str(fake_proxy),
+                            "args": [
+                                "--transport",
+                                "streamablehttp",
+                                "https://mcp.notion.com/mcp",
+                            ],
+                        }
+                    }
+                }
+            )
+        )
+        before = config_file.read_text()
+        result = runner.invoke(app, ["delete", "notion"])
+        assert result.exit_code == 0
+        assert f"Target: {config_file}" in result.output
+        assert "--- current" in result.output
+        assert "+++ proposed" in result.output
+        assert '-    "notion"' in result.output
+        assert 'Will remove "notion".' in result.output
+        assert "--write" in result.output
+        assert config_file.read_text() == before
+
+    def test_write_removes_entry(self, config_env):
+        config_file, fake_proxy = config_env
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": {
+                            "command": str(fake_proxy),
+                            "args": [
+                                "--transport",
+                                "streamablehttp",
+                                "https://mcp.notion.com/mcp",
+                            ],
+                        },
+                        "linear": {
+                            "command": str(fake_proxy),
+                            "args": [
+                                "--transport",
+                                "streamablehttp",
+                                "https://mcp.linear.app/mcp",
+                            ],
+                        },
+                    },
+                    "other": "keep",
+                }
+            )
+        )
+        result = runner.invoke(app, ["delete", "notion", "--write"])
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        assert "notion" not in data["mcpServers"]
+        assert "linear" in data["mcpServers"]
+        assert data["other"] == "keep"
+        assert config_file.with_suffix(".json.bak").exists()
+        assert 'Removed "notion".' in result.output
+        assert "Restart Claude Desktop" in result.output
+
+    def test_entry_not_found(self, config_env):
+        config_file, fake_proxy = config_env
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": {
+                            "command": str(fake_proxy),
+                            "args": [
+                                "--transport",
+                                "streamablehttp",
+                                "https://mcp.notion.com/mcp",
+                            ],
+                        }
+                    }
+                }
+            )
+        )
+        before = config_file.read_text()
+        result = runner.invoke(app, ["delete", "foo"])
+        assert result.exit_code == 1
+        assert '"foo" not found' in result.output
+        assert config_file.read_text() == before
+
+    def test_no_config_file(self, config_env):
+        config_file, _ = config_env
+        assert not config_file.exists()
+        result = runner.invoke(app, ["delete", "notion"])
+        assert result.exit_code == 1
+        assert '"notion" not found' in result.output
+
+    def test_corrupt_config(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text("not json at all")
+        result = runner.invoke(app, ["delete", "notion"])
+        assert result.exit_code == 1
+        assert "Failed to parse JSON config file" in result.output
+
+    def test_delete_then_revert_restores(self, config_env):
+        config_file, fake_proxy = config_env
+        original = {
+            "mcpServers": {
+                "notion": {
+                    "command": str(fake_proxy),
+                    "args": [
+                        "--transport",
+                        "streamablehttp",
+                        "https://mcp.notion.com/mcp",
+                    ],
+                },
+                "linear": {
+                    "command": str(fake_proxy),
+                    "args": [
+                        "--transport",
+                        "streamablehttp",
+                        "https://mcp.linear.app/mcp",
+                    ],
+                },
+            }
+        }
+        config_file.write_text(json.dumps(original))
+        result = runner.invoke(app, ["delete", "notion", "--write"])
+        assert result.exit_code == 0
+        result = runner.invoke(app, ["revert"])
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        assert "notion" in data["mcpServers"]
+        assert "linear" in data["mcpServers"]
+
+
 class TestImportPreview:
     def test_preview_basic(self, config_env, tmp_path):
         config_file, _ = config_env

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -18,7 +18,7 @@ from cdcasasagi.desktop_config import (
     load_config,
     merge_entry,
     plan_import,
-    remove_entry,
+    remove_entries_by_url,
     revert_config,
     write_config,
 )
@@ -128,39 +128,107 @@ class TestMergeEntry:
         assert "notion" not in config["mcpServers"]
 
 
-class TestRemoveEntry:
-    def test_removes_existing_entry(self):
+class TestRemoveEntriesByUrl:
+    def _managed(self, url, command="mcp-proxy"):
+        return {"command": command, "args": ["--transport", "streamablehttp", url]}
+
+    def test_removes_matching_managed_entry(self):
+        url = "https://mcp.notion.com/mcp"
         config = {
-            "mcpServers": {"notion": {"command": "x"}, "linear": {"command": "y"}}
+            "mcpServers": {
+                "notion": self._managed(url),
+                "linear": self._managed("https://mcp.linear.app/mcp"),
+            }
         }
-        result = remove_entry(config, "notion")
+        result, removed = remove_entries_by_url(config, url)
+        assert removed == ["notion"]
         assert "notion" not in result["mcpServers"]
         assert "linear" in result["mcpServers"]
 
     def test_preserves_unrelated_top_level_keys(self):
-        config = {"mcpServers": {"notion": {"command": "x"}}, "other": "keep"}
-        result = remove_entry(config, "notion")
+        url = "https://mcp.notion.com/mcp"
+        config = {"mcpServers": {"notion": self._managed(url)}, "other": "keep"}
+        result, _ = remove_entries_by_url(config, url)
         assert result["other"] == "keep"
 
-    def test_missing_name_raises(self):
-        config = {"mcpServers": {"notion": {"command": "x"}}}
+    def test_missing_url_raises(self):
+        config = {"mcpServers": {"notion": self._managed("https://mcp.notion.com/mcp")}}
         with pytest.raises(EntryNotFoundError):
-            remove_entry(config, "linear")
+            remove_entries_by_url(config, "https://other.example.com/mcp")
 
     def test_missing_mcpservers_raises(self):
         config = {"other": "value"}
         with pytest.raises(EntryNotFoundError):
-            remove_entry(config, "notion")
+            remove_entries_by_url(config, "https://mcp.notion.com/mcp")
 
     def test_empty_mcpservers_raises(self):
         config = {"mcpServers": {}}
         with pytest.raises(EntryNotFoundError):
-            remove_entry(config, "notion")
+            remove_entries_by_url(config, "https://mcp.notion.com/mcp")
 
     def test_does_not_mutate_original(self):
-        config = {"mcpServers": {"notion": {"command": "x"}}}
-        remove_entry(config, "notion")
+        url = "https://mcp.notion.com/mcp"
+        config = {"mcpServers": {"notion": self._managed(url)}}
+        remove_entries_by_url(config, url)
         assert "notion" in config["mcpServers"]
+
+    def test_ignores_non_mcp_proxy_command(self):
+        url = "https://mcp.notion.com/mcp"
+        config = {
+            "mcpServers": {
+                "impostor": {
+                    "command": "/usr/bin/some-other-tool",
+                    "args": ["--transport", "streamablehttp", url],
+                }
+            }
+        }
+        with pytest.raises(EntryNotFoundError):
+            remove_entries_by_url(config, url)
+        assert "impostor" in config["mcpServers"]
+
+    def test_ignores_malformed_args_shape(self):
+        url = "https://mcp.notion.com/mcp"
+        config = {
+            "mcpServers": {
+                "short": {"command": "mcp-proxy", "args": [url]},
+                "wrong_flag": {
+                    "command": "mcp-proxy",
+                    "args": ["--other", "x", url],
+                },
+            }
+        }
+        with pytest.raises(EntryNotFoundError):
+            remove_entries_by_url(config, url)
+
+    def test_mcp_proxy_exe_command_matches(self):
+        url = "https://mcp.notion.com/mcp"
+        config = {
+            "mcpServers": {
+                "notion": {
+                    "command": "mcp-proxy.exe",
+                    "args": ["--transport", "streamablehttp", url],
+                }
+            }
+        }
+        result, removed = remove_entries_by_url(config, url)
+        assert removed == ["notion"]
+        assert "notion" not in result["mcpServers"]
+
+    def test_removes_all_duplicate_url_managed_entries(self):
+        """Hand-edited config with two managed entries sharing a URL: both go."""
+        url = "https://mcp.notion.com/mcp"
+        config = {
+            "mcpServers": {
+                "notion": self._managed(url),
+                "notion-2": self._managed(url),
+                "other": self._managed("https://other.example.com/mcp"),
+            }
+        }
+        result, removed = remove_entries_by_url(config, url)
+        assert sorted(removed) == ["notion", "notion-2"]
+        assert "notion" not in result["mcpServers"]
+        assert "notion-2" not in result["mcpServers"]
+        assert "other" in result["mcpServers"]
 
 
 class TestWriteConfig:

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -8,6 +8,7 @@ from cdcasasagi.desktop_config import (
     BackupNotFoundError,
     ConfigError,
     EntryExistsError,
+    EntryNotFoundError,
     apply_import,
     backup_path,
     build_entry,
@@ -17,6 +18,7 @@ from cdcasasagi.desktop_config import (
     load_config,
     merge_entry,
     plan_import,
+    remove_entry,
     revert_config,
     write_config,
 )
@@ -124,6 +126,41 @@ class TestMergeEntry:
         entry = {"command": "x", "args": []}
         merge_entry(config, "notion", entry, force=False)
         assert "notion" not in config["mcpServers"]
+
+
+class TestRemoveEntry:
+    def test_removes_existing_entry(self):
+        config = {
+            "mcpServers": {"notion": {"command": "x"}, "linear": {"command": "y"}}
+        }
+        result = remove_entry(config, "notion")
+        assert "notion" not in result["mcpServers"]
+        assert "linear" in result["mcpServers"]
+
+    def test_preserves_unrelated_top_level_keys(self):
+        config = {"mcpServers": {"notion": {"command": "x"}}, "other": "keep"}
+        result = remove_entry(config, "notion")
+        assert result["other"] == "keep"
+
+    def test_missing_name_raises(self):
+        config = {"mcpServers": {"notion": {"command": "x"}}}
+        with pytest.raises(EntryNotFoundError):
+            remove_entry(config, "linear")
+
+    def test_missing_mcpservers_raises(self):
+        config = {"other": "value"}
+        with pytest.raises(EntryNotFoundError):
+            remove_entry(config, "notion")
+
+    def test_empty_mcpservers_raises(self):
+        config = {"mcpServers": {}}
+        with pytest.raises(EntryNotFoundError):
+            remove_entry(config, "notion")
+
+    def test_does_not_mutate_original(self):
+        config = {"mcpServers": {"notion": {"command": "x"}}}
+        remove_entry(config, "notion")
+        assert "notion" in config["mcpServers"]
 
 
 class TestWriteConfig:


### PR DESCRIPTION
## Summary
- Add `cdcasasagi delete <URL>` subcommand as the reverse of `add`: preview by default, `--write` to apply (closes #40).
- `remove_entries_by_url` in `desktop_config.py` filters to cdcasasagi-managed entries (same rules as `list_mcp_proxy_entries`), so hand-added entries sharing a URL are left alone.
- `EntryNotFoundError` raised when the URL has no managed match.
- Reuses `write_config`'s `.bak` behavior, so `revert` composes for free.

## Design notes
- URL was chosen over name because layer-2 users copy from `cdcasasagi list` output (which exposes URLs) and URL uniqueness is already enforced by `add`/`import` via `DuplicateUrlError`.
- Messages include the resolved name(s): `Will remove "notion" (https://mcp.notion.com/mcp).`
- If a hand-edited config has multiple managed entries sharing a URL, all of them are removed.

## Test plan
- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` (219 passed)
- [x] Manual smoke: add -> list -> delete preview -> delete --write -> list empty -> revert -> delete non-existent URL (exit 1)

https://claude.ai/code/session_017Amju4Fca7v4sxUA21m6NC