### PR TITLE
e2e: Add Gauge spec for `list` seeded via a pre-written config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ uv run --no-sync pytest
 
 Tests use `pytest` with `typer.testing.CliRunner`. The `config_env` fixture sets `CLAUDE_DESKTOP_CONFIG` to a temp path and stubs `mcp_proxy.sys.executable` — no real filesystem side effects.
 
-End-to-end tests live under `e2e/specs/` and are written with [Gauge](https://gauge.org/). Specs are organized by *behavior* rather than per-command — e.g. preview vs `--write` round-trip (`add.spec` / `add_write.spec`), all-or-nothing semantics (`import_conflict.spec`), the non-developer handoff journey (`handoff.spec`), and error surfacing through the subprocess boundary (`errors.spec`). Not every command has its own spec; a command is only covered here when its behavior needs to be verified through a real subprocess (exit codes, stdin/stdout, `.bak` round-trips).
+End-to-end tests live under `e2e/specs/` and are written with [Gauge](https://gauge.org/). Specs are organized by *behavior* rather than per-command — e.g. preview vs `--write` round-trip (`add.spec` / `add_write.spec`), all-or-nothing semantics (`import_conflict.spec`), the non-developer handoff journey (`handoff.spec`), error surfacing through the subprocess boundary (`errors.spec`), and read-only behavior over pre-seeded configs that include hand-added, non-`mcp-proxy` entries (`list.spec`). Not every command has its own spec; a command is only covered here when its behavior needs to be verified through a real subprocess (exit codes, stdin/stdout, `.bak` round-trips).
 
 When adding or changing a command, decide whether any of these behaviors apply and add/update the matching spec. Do not skip this step silently — if you judge no E2E is needed, say so explicitly in the PR.
 

--- a/e2e/specs/list.spec
+++ b/e2e/specs/list.spec
@@ -1,0 +1,54 @@
+# cdcasasagi list
+
+E2E for `cdcasasagi list`, which prints cdcasasagi-managed MCP servers as
+`name : url`. These scenarios seed `claude_desktop_config.json` directly
+(no `add --write`) so they can cover hand-added entries whose `command` is
+not `mcp-proxy` -- a shape `add` would never produce.
+
+## Mixed managed and hand-added entries list only the managed one
+
+* Claude Desktop's config has the following mcpServers entries
+   |name  |command  |args                                                 |
+   |------|---------|-----------------------------------------------------|
+   |notion|mcp-proxy|--transport,streamablehttp,https://mcp.notion.com/mcp|
+   |legacy|node     |/path/to/hand-added-server.js                        |
+* Run cdcasasagi "list"
+* The last command succeeds
+* stdout contains "notion : https://mcp.notion.com/mcp"
+* stdout does not contain "legacy"
+* The config file is unchanged
+
+## A config with no mcpServers key lists nothing
+
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "list"
+* The last command succeeds
+* stdout contains "No mcp-proxy MCP servers configured."
+* stdout does not contain " : "
+* The config file is unchanged
+
+## An empty mcpServers object lists nothing
+
+* Claude Desktop's config has an empty mcpServers object
+* Run cdcasasagi "list"
+* The last command succeeds
+* stdout contains "No mcp-proxy MCP servers configured."
+* stdout does not contain " : "
+* The config file is unchanged
+
+## Multiple managed entries are printed sorted by name
+
+* Claude Desktop's config has the following mcpServers entries
+   |name  |command  |args                                                |
+   |------|---------|----------------------------------------------------|
+   |zeta  |mcp-proxy|--transport,streamablehttp,https://z.example.com/mcp|
+   |alpha |mcp-proxy|--transport,streamablehttp,https://a.example.com/mcp|
+   |middle|mcp-proxy|--transport,streamablehttp,https://m.example.com/mcp|
+* Run cdcasasagi "list"
+* The last command succeeds
+* stdout contains "alpha"
+* stdout contains "middle"
+* stdout contains "zeta"
+* stdout has "alpha" listed before "middle"
+* stdout has "middle" listed before "zeta"
+* The config file is unchanged

--- a/e2e/step_impl/steps_common.py
+++ b/e2e/step_impl/steps_common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import subprocess
@@ -38,6 +39,39 @@ def given_claude_desktop_without_mcp_servers():
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(_INITIAL_CONFIG, encoding="utf-8")
     data_store.scenario["initial_config"] = _INITIAL_CONFIG
+
+
+def _seed_config(config: dict) -> None:
+    _guard_against_overwriting_real_config()
+    text = json.dumps(config)
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    data_store.scenario["initial_config"] = text
+
+
+@step("Claude Desktop's config has the following mcpServers entries <table>")
+def given_config_with_entries(table):
+    """Seed claude_desktop_config.json directly, bypassing `add --write`.
+
+    The ``args`` column is a comma-separated list. This lets scenarios create
+    entries whose ``command`` is something other than ``mcp-proxy`` -- a shape
+    ``add`` would never produce -- so we can exercise how ``list``/``delete``
+    treat hand-edited entries.
+    """
+    names = table.get_column_values_with_name("name")
+    commands = table.get_column_values_with_name("command")
+    args_column = table.get_column_values_with_name("args")
+    servers: dict[str, dict] = {}
+    for name, cmd, args in zip(names, commands, args_column):
+        args_list = [a for a in args.split(",") if a]
+        servers[name] = {"command": cmd, "args": args_list}
+    _seed_config({"mcpServers": servers})
+
+
+@step("Claude Desktop's config has an empty mcpServers object")
+def given_config_with_empty_mcp_servers():
+    _seed_config({"mcpServers": {}})
 
 
 @step("Run cdcasasagi <args>")

--- a/e2e/step_impl/steps_list.py
+++ b/e2e/step_impl/steps_list.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from getgauge.python import data_store, step
+
+
+@step("The last command succeeds")
+def assert_last_command_succeeded():
+    result = data_store.scenario["last_result"]
+    assert result.returncode == 0, (
+        f"expected zero exit, got {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+@step("stdout contains <text>")
+def assert_stdout_contains(text):
+    result = data_store.scenario["last_result"]
+    assert text in result.stdout, (
+        f"stdout does not contain {text!r}\nstdout:\n{result.stdout}"
+    )
+
+
+@step("stdout does not contain <text>")
+def assert_stdout_does_not_contain(text):
+    result = data_store.scenario["last_result"]
+    assert text not in result.stdout, (
+        f"stdout unexpectedly contains {text!r}\nstdout:\n{result.stdout}"
+    )
+
+
+@step("stdout has <earlier> listed before <later>")
+def assert_stdout_order(earlier, later):
+    result = data_store.scenario["last_result"]
+    stdout = result.stdout
+    i_earlier = stdout.find(earlier)
+    i_later = stdout.find(later)
+    assert i_earlier != -1, f"{earlier!r} not found in stdout:\n{stdout}"
+    assert i_later != -1, f"{later!r} not found in stdout:\n{stdout}"
+    assert i_earlier < i_later, (
+        f"expected {earlier!r} before {later!r}, but {earlier!r} at {i_earlier} "
+        f"and {later!r} at {i_later}\nstdout:\n{stdout}"
+    )


### PR DESCRIPTION
## Summary

- Add `e2e/specs/list.spec` with four scenarios covering `cdcasasagi list`: a mixed managed + hand-added config, a config with no `mcpServers` key, a config with an empty `mcpServers`, and sort-by-name ordering across multiple managed entries.
- Introduce a new seeding pattern that writes `claude_desktop_config.json` directly as fixture data (via two shared steps in `steps_common.py`) so scenarios can produce entries whose `command` is not `mcp-proxy` -- a shape `add` would never produce.
- Add `steps_list.py` with stdout/success/ordering assertion steps, and mention `list.spec` in the AGENTS.md E2E paragraph.

Closes #42.

Parallel with #43 (delete). Since #43 is not yet merged, this PR introduces the seeding helper; #43 can rebase and reuse it.

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/ e2e/`
- [x] `uv run --no-sync ruff check --fix src/ tests/ e2e/`
- [x] `uv run --no-sync pytest` (219 passed)
- [x] `cd e2e && CLAUDE_DESKTOP_CONFIG=/tmp/test-claude-config.json uv run gauge run specs` (7 specs / 21 scenarios pass, including 4 new `list.spec` scenarios)

https://claude.ai/code/session_01AHWojxNRUXNTYSzPYkpxnE