### PR TITLE
Keep `add --force` rename diff minimal

### DIFF
--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -117,6 +117,35 @@ def build_entry(mcp_proxy_path: Path, transport: str, url: str) -> dict[str, Any
     }
 
 
+def _replace_preserving_order(
+    servers: dict[str, Any],
+    name: str,
+    entry: dict[str, Any],
+    replaces: list[str],
+) -> dict[str, Any]:
+    """Return a new ``mcpServers`` dict with ``name -> entry``, dropping every
+    key in ``replaces``.
+
+    ``name`` takes the earliest original position among ``replaces + [name]``
+    that exists in *servers*. If none of those keys are present, ``name`` is
+    appended at the end. Preserving the slot keeps the preview diff limited to
+    the renamed key instead of showing a delete-and-append of the whole entry.
+    """
+    drop = set(replaces) | {name}
+    out: dict[str, Any] = {}
+    inserted = False
+    for key, val in servers.items():
+        if key in drop:
+            if not inserted:
+                out[name] = entry
+                inserted = True
+        else:
+            out[key] = val
+    if not inserted:
+        out[name] = entry
+    return out
+
+
 def merge_entry(
     config: dict[str, Any],
     name: str,
@@ -126,23 +155,20 @@ def merge_entry(
     url: str | None = None,
 ) -> dict[str, Any]:
     config = json.loads(json.dumps(config))  # deep copy
-    if "mcpServers" not in config:
-        config["mcpServers"] = {}
+    servers = config.setdefault("mcpServers", {})
 
+    others: list[str] = []
     if url is not None:
         others = [n for n in find_entry_names_by_url(config, url) if n != name]
-        if others:
-            if not force:
-                raise DuplicateUrlError(
-                    f'URL already configured as "{others[0]}". Use --force to overwrite'
-                )
-            for n in others:
-                del config["mcpServers"][n]
+        if others and not force:
+            raise DuplicateUrlError(
+                f'URL already configured as "{others[0]}". Use --force to overwrite'
+            )
 
-    if name in config["mcpServers"] and not force:
+    if name in servers and not others and not force:
         raise EntryExistsError(f'"{name}" already exists. Use --force to overwrite')
 
-    config["mcpServers"][name] = entry
+    config["mcpServers"] = _replace_preserving_order(servers, name, entry, others)
     return config
 
 
@@ -221,12 +247,15 @@ def apply_import(
             config["mcpServers"][name] = entry
         elif action == "conflict" and force:
             args = entry.get("args", [])
-            if args:
-                url = args[-1]
-                for other in find_entry_names_by_url(config, url):
-                    if other != name:
-                        del config["mcpServers"][other]
-            config["mcpServers"][name] = entry
+            url = args[-1] if args else None
+            replaces = (
+                [n for n in find_entry_names_by_url(config, url) if n != name]
+                if url is not None
+                else []
+            )
+            config["mcpServers"] = _replace_preserving_order(
+                config["mcpServers"], name, entry, replaces
+            )
     return config
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -340,6 +340,33 @@ class TestAddErrors:
         assert "my-notion" in data["mcpServers"]
         assert "notion" not in data["mcpServers"]
 
+    def test_force_rename_preview_diff_is_minimal(self, config_env):
+        """A rename via --force must only touch the renamed key in the diff,
+        not reorder the other entries into the added/removed block.
+        """
+        config_file, fake_proxy = config_env
+        url_a = "https://mcp.notion.com/mcp"
+        url_b = "https://developers.openai.com/mcp"
+        notion = {
+            "command": str(fake_proxy),
+            "args": ["--transport", "streamablehttp", url_a],
+        }
+        openai = {
+            "command": str(fake_proxy),
+            "args": ["--transport", "streamablehttp", url_b],
+        }
+        config_file.write_text(
+            json.dumps({"mcpServers": {"notion": notion, "openai": openai}})
+        )
+        result = runner.invoke(app, ["add", url_a, "--name", "my-notion", "--force"])
+        assert result.exit_code == 0
+        assert '-    "notion":' in result.output
+        assert '+    "my-notion":' in result.output
+        # The untouched entry must not appear as an add/remove in the diff.
+        for line in result.output.splitlines():
+            if line.startswith(("+", "-")) and not line.startswith(("+++", "---")):
+                assert '"openai"' not in line, line
+
     def test_duplicate_url_force_removes_all(self, config_env):
         config_file, fake_proxy = config_env
         url = "https://mcp.notion.com/mcp"

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -127,6 +127,46 @@ class TestMergeEntry:
         merge_entry(config, "notion", entry, force=False)
         assert "notion" not in config["mcpServers"]
 
+    def test_url_force_rename_preserves_position(self):
+        url_a = "https://a.example/mcp"
+        url_b = "https://b.example/mcp"
+        config = {
+            "mcpServers": {
+                "a": _entry(url_a),
+                "b": _entry(url_b),
+            }
+        }
+        new = _entry(url_a, command="new")
+        result = merge_entry(config, "c", new, force=True, url=url_a)
+        assert list(result["mcpServers"].keys()) == ["c", "b"]
+        assert result["mcpServers"]["c"] == new
+
+    def test_url_force_multiple_aliases_collapse_to_first_slot(self):
+        url_a = "https://a.example/mcp"
+        url_b = "https://b.example/mcp"
+        config = {
+            "mcpServers": {
+                "a": _entry(url_a),
+                "b": _entry(url_a),
+                "c": _entry(url_b),
+            }
+        }
+        new = _entry(url_a, command="new")
+        result = merge_entry(config, "new", new, force=True, url=url_a)
+        assert list(result["mcpServers"].keys()) == ["new", "c"]
+
+    def test_same_name_overwrite_preserves_position(self):
+        config = {
+            "mcpServers": {
+                "a": {"command": "old"},
+                "b": {"command": "z"},
+            }
+        }
+        new = {"command": "new"}
+        result = merge_entry(config, "a", new, force=True)
+        assert list(result["mcpServers"].keys()) == ["a", "b"]
+        assert result["mcpServers"]["a"] == new
+
 
 class TestRemoveEntriesByUrl:
     def _managed(self, url, command="mcp-proxy"):
@@ -427,6 +467,20 @@ class TestApplyImport:
         assert "my-notion" in result["mcpServers"]
         assert "notion" not in result["mcpServers"]
         assert result["mcpServers"]["my-notion"] == incoming
+
+    def test_url_alias_conflict_force_preserves_position(self):
+        """The renamed entry keeps the slot of the aliased entry it replaces."""
+        url = "https://mcp.notion.com/mcp"
+        url2 = "https://other.example/mcp"
+        config = {
+            "mcpServers": {
+                "notion": _entry(url),
+                "other": _entry(url2),
+            }
+        }
+        plan = [("my-notion", "conflict", _entry(url, command="new"))]
+        result = apply_import(config, plan, force=True)
+        assert list(result["mcpServers"].keys()) == ["my-notion", "other"]
 
     def test_url_alias_conflict_without_force_does_not_remove(self):
         url = "https://mcp.notion.com/mcp"


### PR DESCRIPTION
## Summary

When `cdcasasagi add --force` (or an import conflict with `--force`) renames an entry that shares a URL with an existing managed entry, the preview diff now only shows the renamed key — not a large "delete the old entry, append a new one at the bottom" block.

### Before

With two entries in `claude_desktop_config.json`, renaming the first via `add <same-URL> --name <new> --force`, `merge_entry` deleted the aliased key and then assigned the new key, which Python appends at the end of the `dict`. The serialized JSON therefore reordered to `{entry-2, new-name}`, producing a noisy diff that looked like a delete of entry-1 plus an append of `new-name`.

### After

A new helper `_replace_preserving_order` rebuilds the `mcpServers` dict in the original order, substituting `name -> entry` at the earliest slot occupied by any removed or replaced key. The rename preview now limits the diff to the key line (and whatever data actually changed).

The same helper is also used in `apply_import` so the `import --verbose` diff benefits too.

## Test plan

- [x] Added unit tests in `tests/test_desktop_config.py`
  - `TestMergeEntry.test_url_force_rename_preserves_position`
  - `TestMergeEntry.test_url_force_multiple_aliases_collapse_to_first_slot`
  - `TestMergeEntry.test_same_name_overwrite_preserves_position`
  - `TestApplyImport.test_url_alias_conflict_force_preserves_position`
- [x] Added CLI test `tests/test_cli.py::TestAdd::test_force_rename_preview_diff_is_minimal` asserting the untouched sibling entry does not appear as a `+`/`-` line
- [x] `uv run --no-sync ruff format src/ tests/` / `ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` — 224 passed
- [x] Manual smoke test with two managed entries confirms the diff only shows the renamed key

https://claude.ai/code/session_01YYrFQ72TcbVjqnEhu3MB3A