### PR TITLE
e2e: Verify command path is absolute and uses native separator

### DIFF
--- a/e2e/specs/add_write.spec
+++ b/e2e/specs/add_write.spec
@@ -53,3 +53,13 @@ E2E for the `--write` round-trip (write the config file / create .bak / revert f
 * "notion,developers" entries are written to the config file
 * Run cdcasasagi "revert"
 * "notion" entry is written to the config file
+
+## The written command is an absolute path using the platform's native separator
+
+The command string differs by OS: forward slashes on macOS, backslashes on Windows
+(plus the `.exe` suffix). We mistook a forward-slash path for valid on Windows once;
+this scenario locks in the native shape on each runner.
+
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write"
+* The "notion" entry's command is an absolute path using the platform's native separator

--- a/e2e/step_impl/steps_add_write.py
+++ b/e2e/step_impl/steps_add_write.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+from pathlib import Path
 
 from getgauge.python import data_store, step
 
@@ -77,4 +79,27 @@ def assert_entry_url(name, url):
     args = entry.get("args", [])
     assert args and args[-1] == url, (
         f'expected URL {url!r} at end of args for "{name}", got args={args!r}'
+    )
+
+
+@step(
+    "The <name> entry's command is an absolute path using the platform's native separator"
+)
+def assert_command_native_separator(name):
+    config = _load_json(config_path())
+    entry = config.get("mcpServers", {}).get(name)
+    assert entry is not None, f'entry "{name}" not found in config'
+    command = entry.get("command", "")
+    assert Path(command).is_absolute(), f"command is not absolute: {command!r}"
+    expected_basename = "mcp-proxy.exe" if os.name == "nt" else "mcp-proxy"
+    assert Path(command).name == expected_basename, (
+        f"expected command basename {expected_basename!r}, got {Path(command).name!r}"
+    )
+    foreign_sep = "/" if os.sep == "\\" else "\\"
+    assert foreign_sep not in command, (
+        f"command contains foreign separator {foreign_sep!r} "
+        f"(native is {os.sep!r}): {command!r}"
+    )
+    assert os.sep in command, (
+        f"command does not contain native separator {os.sep!r}: {command!r}"
     )


### PR DESCRIPTION
## Summary
- Add a single E2E scenario to `add_write.spec` that asserts the `command` field written by `add --write` is an absolute path using the platform's native separator (`/` on macOS, `\` on Windows, with `mcp-proxy.exe` as the basename on Windows).
- Path-separator behavior wasn't observable from the existing unit tests because they stub `mcp_proxy.sys.executable`. Pinning it in E2E means each Windows / macOS runner now fails loudly if the written `command` ever gets a foreign separator or a wrong basename.

## Why
Real configs hit a path-separator mismatch once before. Locking in this single round-trip on both `windows-latest` and `macos-latest` raises the resolution on what each platform actually writes.

## Test plan
- [x] CI: `e2e (macos-latest)` passes (asserts `/` separator, `mcp-proxy` basename)
- [x] CI: `e2e (windows-latest)` passes (asserts `\` separator, `mcp-proxy.exe` basename)

https://claude.ai/code/session_01QB774bU3aD3DZ4dJ6N5DHo