### PR TITLE
Add --windows-forward-slashes to write '/' in command path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ The written entry looks like this:
 }
 ```
 
+On Windows, the `command` path normally uses `\`. Pass `--windows-forward-slashes` to write `/` instead, so the resulting JSON line matches what the same command produces on macOS:
+
+```
+cdcasasagi add https://developers.openai.com/mcp --write --windows-forward-slashes
+```
+
+The flag is Windows-only and exits with an error on macOS/Linux.
+
 ### delete
 
 Remove an entry from the Claude Desktop config by URL:
@@ -97,6 +105,8 @@ cdcasasagi import - --write
 # Paste JSONL, then press Enter on a blank line to finish
 # (Ctrl+D / Ctrl+Z also works)
 ```
+
+`import` accepts the same `--windows-forward-slashes` flag as `add` and applies it to every imported entry. Windows-only — errors on macOS/Linux.
 
 ### list
 

--- a/e2e/specs/add_write.spec
+++ b/e2e/specs/add_write.spec
@@ -63,3 +63,15 @@ this scenario locks in the native shape on each runner.
 * Claude Desktop is used with no MCP server entries
 * Run cdcasasagi "add https://mcp.notion.com/mcp --write"
 * The "notion" entry's command is an absolute path using the platform's native separator
+
+## --windows-forward-slashes opts into '/' on Windows and errors elsewhere
+
+The flag is intended for developers preparing a `--write` command for a Windows
+non-developer to copy-paste, so the resulting JSON line matches what the same
+command produces on macOS. On Windows the runner asserts the command uses `/`
+instead of `\`. On macOS/Linux the runner asserts the command refuses to run
+and writes nothing.
+
+* Claude Desktop is used with no MCP server entries
+* Run cdcasasagi "add https://mcp.notion.com/mcp --write --windows-forward-slashes"
+* The --windows-forward-slashes outcome matches the platform for the "notion" entry

--- a/e2e/step_impl/steps_add_write.py
+++ b/e2e/step_impl/steps_add_write.py
@@ -103,3 +103,45 @@ def assert_command_native_separator(name):
     assert os.sep in command, (
         f"command does not contain native separator {os.sep!r}: {command!r}"
     )
+
+
+@step(
+    "The --windows-forward-slashes outcome matches the platform for the <name> entry"
+)
+def assert_windows_forward_slashes_outcome(name):
+    """Single step asserting platform-correct behavior of --windows-forward-slashes.
+
+    On Windows: the entry's command is an absolute mcp-proxy.exe path written
+    with `/` and no `\\`. On macOS/Linux: the command failed with the
+    "only valid on Windows" error and no config file was written.
+    """
+    result = data_store.scenario["last_result"]
+    if os.name == "nt":
+        assert result.returncode == 0, (
+            f"expected success on Windows, got exit {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        config = _load_json(config_path())
+        entry = config.get("mcpServers", {}).get(name)
+        assert entry is not None, f'entry "{name}" not found in config'
+        command = entry.get("command", "")
+        assert "/" in command, f"expected '/' in command on Windows, got {command!r}"
+        assert "\\" not in command, (
+            f"expected no '\\\\' in command on Windows, got {command!r}"
+        )
+        assert command.endswith("mcp-proxy.exe"), (
+            f"expected command basename mcp-proxy.exe, got {command!r}"
+        )
+    else:
+        assert result.returncode != 0, (
+            f"expected non-zero exit on POSIX, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert "only valid on Windows" in combined, (
+            f"expected 'only valid on Windows' in output, got:\n{combined}"
+        )
+        config = _load_json(config_path())
+        assert config.get("mcpServers", {}) == {}, (
+            f"expected no entries written on POSIX, got {config.get('mcpServers')!r}"
+        )

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -77,6 +77,15 @@ def _validate_url(url: str) -> None:
         raise typer.Exit(code=1)
 
 
+def _require_windows_for_forward_slashes(flag: bool) -> None:
+    if flag and os.name != "nt":
+        typer.echo(
+            "--windows-forward-slashes is only valid on Windows.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+
 @app.command()
 def add(
     url: str = typer.Argument(..., help="URL of the MCP server"),
@@ -86,8 +95,14 @@ def add(
     ),
     force: bool = typer.Option(False, help="Overwrite existing entry"),
     write: bool = typer.Option(False, help="Actually write to the file"),
+    windows_forward_slashes: bool = typer.Option(
+        False,
+        "--windows-forward-slashes",
+        help="Write command path with '/' instead of '\\' (Windows only).",
+    ),
 ) -> None:
     _validate_url(url)
+    _require_windows_for_forward_slashes(windows_forward_slashes)
 
     name_was_derived = name is None
     if name is None:
@@ -111,7 +126,9 @@ def add(
         typer.echo(str(e), err=True)
         raise typer.Exit(code=1)
 
-    entry = desktop_config.build_entry(proxy_path, transport, url)
+    entry = desktop_config.build_entry(
+        proxy_path, transport, url, forward_slashes=windows_forward_slashes
+    )
 
     try:
         merged = desktop_config.merge_entry(current_config, name, entry, force, url=url)
@@ -351,6 +368,8 @@ def _collect_entry_errors(
 def _resolve_import_entries(
     raw_entries: list[dict],
     proxy_path: Path,
+    *,
+    forward_slashes: bool = False,
 ) -> list[tuple[str, str, dict]]:
     """Validate URLs, derive names, build config entries.
 
@@ -362,7 +381,13 @@ def _resolve_import_entries(
         raise typer.Exit(code=1)
 
     return [
-        (name, url, desktop_config.build_entry(proxy_path, transport, url))
+        (
+            name,
+            url,
+            desktop_config.build_entry(
+                proxy_path, transport, url, forward_slashes=forward_slashes
+            ),
+        )
         for name, url, transport in validated
     ]
 
@@ -410,7 +435,14 @@ def import_cmd(
     force: bool = typer.Option(False, help="Overwrite existing entries on conflict"),
     write: bool = typer.Option(False, help="Actually write to the file"),
     verbose: bool = typer.Option(False, help="Show full diff in preview"),
+    windows_forward_slashes: bool = typer.Option(
+        False,
+        "--windows-forward-slashes",
+        help="Write command path with '/' instead of '\\' (Windows only).",
+    ),
 ) -> None:
+    _require_windows_for_forward_slashes(windows_forward_slashes)
+
     # Phase 1: Validation
     raw_entries, source_label, _ = _parse_import_file(file)
 
@@ -425,7 +457,9 @@ def import_cmd(
         typer.echo("\n".join(schema_errors), err=True)
         raise typer.Exit(code=1)
 
-    resolved = _resolve_import_entries(raw_entries, proxy_path)
+    resolved = _resolve_import_entries(
+        raw_entries, proxy_path, forward_slashes=windows_forward_slashes
+    )
 
     cfg_path = desktop_config.config_path()
     try:

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -110,9 +110,18 @@ def list_mcp_proxy_entries(config: dict[str, Any]) -> list[tuple[str, str]]:
     return result
 
 
-def build_entry(mcp_proxy_path: Path, transport: str, url: str) -> dict[str, Any]:
+def build_entry(
+    mcp_proxy_path: Path,
+    transport: str,
+    url: str,
+    *,
+    forward_slashes: bool = False,
+) -> dict[str, Any]:
+    command = str(mcp_proxy_path)
+    if forward_slashes:
+        command = command.replace("\\", "/")
     return {
-        "command": str(mcp_proxy_path),
+        "command": command,
         "args": ["--transport", transport, url],
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 from importlib.metadata import version as pkg_version
+from pathlib import PureWindowsPath
 
 import pytest
 import typer
@@ -401,6 +402,67 @@ class TestAddErrors:
         assert "--name" in result.output
 
 
+class TestAddWindowsForwardSlashes:
+    """Bypass the platform guard so the production behavior of writing
+    forward-slash paths can be exercised on any host. The guard itself is
+    tested separately by ``test_errors_on_posix``."""
+
+    def test_replaces_backslashes_on_windows(self, config_env, monkeypatch):
+        config_file, _ = config_env
+        monkeypatch.setattr(
+            "cdcasasagi.cli._require_windows_for_forward_slashes",
+            lambda flag: None,
+        )
+        monkeypatch.setattr(
+            "cdcasasagi.cli.mcp_proxy.resolve_path",
+            lambda: PureWindowsPath(r"C:\Users\you\.local\bin\mcp-proxy.exe"),
+        )
+        result = runner.invoke(
+            app,
+            [
+                "add",
+                "https://mcp.notion.com/mcp",
+                "--write",
+                "--windows-forward-slashes",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        command = data["mcpServers"]["notion"]["command"]
+        assert command == "C:/Users/you/.local/bin/mcp-proxy.exe"
+        assert "\\" not in command
+
+    def test_errors_on_posix(self, config_env):
+        config_file, _ = config_env
+        result = runner.invoke(
+            app,
+            [
+                "add",
+                "https://mcp.notion.com/mcp",
+                "--write",
+                "--windows-forward-slashes",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "only valid on Windows" in result.output
+        assert not config_file.exists()
+
+    def test_default_off_keeps_native_command(self, config_env, monkeypatch):
+        config_file, _ = config_env
+        monkeypatch.setattr(
+            "cdcasasagi.cli._require_windows_for_forward_slashes",
+            lambda flag: None,
+        )
+        monkeypatch.setattr(
+            "cdcasasagi.cli.mcp_proxy.resolve_path",
+            lambda: PureWindowsPath(r"C:\Users\you\mcp-proxy.exe"),
+        )
+        result = runner.invoke(app, ["add", "https://mcp.notion.com/mcp", "--write"])
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        assert data["mcpServers"]["notion"]["command"] == r"C:\Users\you\mcp-proxy.exe"
+
+
 class TestRevert:
     def test_revert_after_add(self, config_env):
         config_file, _ = config_env
@@ -716,6 +778,56 @@ class TestImportWrite:
         result = runner.invoke(app, ["import", str(input_file), "--write"])
         assert result.exit_code == 0
         assert "No changes needed" in result.output
+
+
+class TestImportWindowsForwardSlashes:
+    def test_replaces_backslashes_on_windows(self, config_env, tmp_path, monkeypatch):
+        config_file, _ = config_env
+        monkeypatch.setattr(
+            "cdcasasagi.cli._require_windows_for_forward_slashes",
+            lambda flag: None,
+        )
+        monkeypatch.setattr(
+            "cdcasasagi.cli.mcp_proxy.resolve_path",
+            lambda: PureWindowsPath(r"C:\Users\you\.local\bin\mcp-proxy.exe"),
+        )
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text(
+            '{"url": "https://mcp.notion.com/mcp"}\n'
+            '{"url": "https://developers.openai.com/mcp"}\n'
+        )
+        result = runner.invoke(
+            app,
+            [
+                "import",
+                str(input_file),
+                "--write",
+                "--windows-forward-slashes",
+            ],
+        )
+        assert result.exit_code == 0
+        data = json.loads(config_file.read_text())
+        for name in ("notion", "developers"):
+            command = data["mcpServers"][name]["command"]
+            assert command == "C:/Users/you/.local/bin/mcp-proxy.exe"
+            assert "\\" not in command
+
+    def test_errors_on_posix(self, config_env, tmp_path):
+        config_file, _ = config_env
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
+        result = runner.invoke(
+            app,
+            [
+                "import",
+                str(input_file),
+                "--write",
+                "--windows-forward-slashes",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "only valid on Windows" in result.output
+        assert not config_file.exists()
 
 
 class TestImportConflicts:

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -1,5 +1,5 @@
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import pytest
 
@@ -86,6 +86,31 @@ class TestBuildEntry:
             "command": "/usr/bin/mcp-proxy",
             "args": ["--transport", "streamablehttp", "https://mcp.notion.com/mcp"],
         }
+
+    def test_forward_slashes_replaces_backslashes(self):
+        win_path = PureWindowsPath(r"C:\Users\you\.local\bin\mcp-proxy.exe")
+        entry = build_entry(
+            win_path,
+            "streamablehttp",
+            "https://example.com/mcp",
+            forward_slashes=True,
+        )
+        assert entry["command"] == "C:/Users/you/.local/bin/mcp-proxy.exe"
+
+    def test_forward_slashes_default_off(self):
+        win_path = PureWindowsPath(r"C:\Users\you\mcp-proxy.exe")
+        entry = build_entry(win_path, "streamablehttp", "https://example.com/mcp")
+        assert entry["command"] == r"C:\Users\you\mcp-proxy.exe"
+
+    def test_forward_slashes_noop_on_posix_path(self):
+        posix_path = PurePosixPath("/usr/bin/mcp-proxy")
+        entry = build_entry(
+            posix_path,
+            "streamablehttp",
+            "https://example.com/mcp",
+            forward_slashes=True,
+        )
+        assert entry["command"] == "/usr/bin/mcp-proxy"
 
 
 class TestMergeEntry:


### PR DESCRIPTION
## Summary

- Add `--windows-forward-slashes` to `add` and `import`. When set, the `command` path written to `claude_desktop_config.json` uses `/` instead of `\` so the JSON line matches what the same command produces on macOS, minimizing cross-platform diffs (motivation: a developer composing a one-shot `--write` command for a Windows non-developer to copy-paste).
- The flag exits non-zero with `"--windows-forward-slashes is only valid on Windows."` on macOS/Linux, so unintended use cannot silently no-op.
- Implementation: `desktop_config.build_entry` gains a keyword-only `forward_slashes: bool = False` that does `command.replace("\\", "/")` when set; both `add` and `import_cmd` plumb the new option through (and `_resolve_import_entries` forwards it to `build_entry`). A small `_require_windows_for_forward_slashes` helper in `cli.py` runs the platform guard early.

## Coverage

- Unit tests for `build_entry` (Windows path, default-off, POSIX no-op) and CLI (`add`/`import` success-on-Windows, error-on-POSIX, default-off regression). Tests bypass the platform guard via monkeypatch when exercising the success path so they run on any host without globally patching `os.name` (which would break `pathlib.Path` on Linux).
- E2E (`add_write.spec`): one new scenario whose step is OS-aware — on Windows it asserts the command uses `/`; on POSIX it asserts the command failed with the expected error and no config was written. Covers both code paths on a single CI runner.
- README: documents the flag under both `add` and `import` with the Windows-only caveat.

## Notes

- Per `AGENTS.md`'s E2E policy: I did not duplicate the scenario into `import_write.spec` because `import` shares the `--windows-forward-slashes` plumbing with `add` (same helper, same `build_entry` argument), and import-specific behavior is covered by unit tests in `tests/test_cli.py::TestImportWindowsForwardSlashes`.
- `uv.lock` showed the usual `exclude-newer` removal after `uv sync`; not included in the commit, per `AGENTS.md`.

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` — 232 passed
- [x] `cd e2e && CLAUDE_DESKTOP_CONFIG=/tmp/test-claude-config.json uv run gauge run specs` — 8 specs / 29 scenarios passed (Linux runner exercised the POSIX-error branch of the new scenario)
- [ ] Verify the new e2e scenario on a Windows runner (covers the success branch)