### PR TITLE
doctor: warn when config is on Windows MSIX virtualized path (#50)

### DIFF
--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -28,29 +28,69 @@ def version() -> None:
 
 @app.command()
 def doctor() -> None:
-    results: list[tuple[str, bool, str]] = []
+    import platform as _platform
+
+    results: list[tuple[str, str, str]] = []
 
     try:
         proxy_path = mcp_proxy.resolve_path()
-        results.append(("mcp-proxy", True, str(proxy_path)))
+        results.append(("mcp-proxy", "pass", str(proxy_path)))
     except mcp_proxy.McpProxyNotFoundError:
-        results.append(("mcp-proxy", False, "not found"))
+        results.append(("mcp-proxy", "fail", "not found"))
 
     cfg_path = desktop_config.config_path()
     if cfg_path.is_file():
-        results.append(("Config file", True, str(cfg_path)))
+        results.append(("Config file", "pass", str(cfg_path)))
     else:
-        results.append(("Config file", False, f"not found: {cfg_path}"))
+        results.append(("Config file", "fail", f"not found: {cfg_path}"))
 
     cfg_dir = cfg_path.parent
     if os.access(cfg_dir, os.W_OK):
-        results.append(("Config directory", True, str(cfg_dir)))
+        results.append(("Config directory", "pass", str(cfg_dir)))
     else:
-        results.append(("Config directory", False, f"not writable: {cfg_dir}"))
+        results.append(("Config directory", "fail", f"not writable: {cfg_dir}"))
+
+    if _platform.system() == "Windows":
+        msix_row = _msix_doctor_row(cfg_path)
+        if msix_row is not None:
+            results.append(msix_row)
 
     typer.echo(output.doctor_message(results))
-    if not all(passed for _, passed, _ in results):
+    if any(status == "fail" for _, status, _ in results):
         raise typer.Exit(code=1)
+
+
+def _msix_doctor_row(cfg_path: Path) -> tuple[str, str, str] | None:
+    if os.environ.get("CLAUDE_DESKTOP_CONFIG"):
+        return None
+    local = os.environ.get("LOCALAPPDATA", "")
+    if local:
+        try:
+            cfg_path.resolve().relative_to((Path(local) / "Packages").resolve())
+            return None
+        except ValueError:
+            pass
+    candidates = desktop_config.windows_msix_config_candidates()
+    if not candidates:
+        return None
+    lines = [
+        "Claude Desktop on MSIX reads config from a virtualized path.",
+        "Candidate path(s):",
+    ]
+    for c in candidates:
+        lines.append(f"  {c}")
+    lines.append("")
+    lines.append("Set CLAUDE_DESKTOP_CONFIG to the path Claude Desktop actually reads:")
+    lines.append(f"  CLAUDE_DESKTOP_CONFIG={candidates[0]}")
+    lines.append("")
+    lines.append(
+        "Confirm via Claude Desktop: Settings > Developer > Edit Config; the "
+        "editor's title bar shows the path. On MSIX installs Edit Config may "
+        "itself open the wrong (%APPDATA%) path "
+        "(see anthropics/claude-code#26073), so cross-check against the "
+        "candidate list above."
+    )
+    return ("Claude Desktop MSIX path", "warn", "\n".join(lines))
 
 
 @app.command(name="list")

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -49,6 +49,28 @@ def config_path() -> Path:
     )
 
 
+def windows_msix_config_candidates() -> list[Path]:
+    """Return claude_desktop_config.json paths under the MSIX virtualized
+    Packages directory, sorted for determinism. Empty list on non-Windows,
+    missing %LOCALAPPDATA%, or no match.
+    """
+    if platform.system() != "Windows":
+        return []
+    local = os.environ.get("LOCALAPPDATA", "")
+    if not local:
+        return []
+    packages = Path(local) / "Packages"
+    if not packages.is_dir():
+        return []
+    candidates: list[Path] = []
+    for pkg in packages.glob("*Claude*"):
+        claude_dir = pkg / "LocalCache" / "Roaming" / "Claude"
+        if claude_dir.is_dir():
+            candidates.append(claude_dir / "claude_desktop_config.json")
+    candidates.sort()
+    return candidates
+
+
 def backup_path(path: Path) -> Path:
     return path.with_suffix(path.suffix + ".bak")
 

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -296,15 +296,21 @@ def list_message(config_path: Path, servers: list[tuple[str, str]]) -> str:
     return "\n".join(lines)
 
 
-def doctor_message(results: list[tuple[str, bool, str]]) -> str:
+def doctor_message(results: list[tuple[str, str, str]]) -> str:
+    tags = {"pass": "[PASS]", "fail": "[FAIL]", "warn": "[WARN]"}
     lines: list[str] = []
-    for label, passed, detail in results:
-        tag = "[PASS]" if passed else "[FAIL]"
-        lines.append(f"{tag} {label}: {detail}")
+    for label, status, detail in results:
+        lines.append(f"{tags[status]} {label}: {detail}")
     lines.append("")
-    fail_count = sum(1 for _, passed, _ in results if not passed)
+    fail_count = sum(1 for _, status, _ in results if status == "fail")
+    warn_count = sum(1 for _, status, _ in results if status == "warn")
     if fail_count == 0:
-        lines.append("All checks passed.")
+        if warn_count == 0:
+            lines.append("All checks passed.")
+        elif warn_count == 1:
+            lines.append("All checks passed (1 warning).")
+        else:
+            lines.append(f"All checks passed ({warn_count} warnings).")
     elif fail_count == 1:
         lines.append("1 check failed. See above for details.")
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,70 @@ class TestDoctor:
         assert "Config file:" in result.output
         assert "Config directory:" in result.output
 
+    def _setup_windows_doctor(self, monkeypatch, tmp_path, with_msix_candidate=True):
+        monkeypatch.delenv("CLAUDE_DESKTOP_CONFIG", raising=False)
+        appdata = tmp_path / "appdata"
+        local = tmp_path / "local"
+        appdata.mkdir()
+        local.mkdir()
+        appdata_cfg_dir = appdata / "Claude"
+        appdata_cfg_dir.mkdir()
+        appdata_cfg = appdata_cfg_dir / "claude_desktop_config.json"
+        appdata_cfg.write_text('{"mcpServers": {}}')
+        monkeypatch.setenv("APPDATA", str(appdata))
+        monkeypatch.setenv("LOCALAPPDATA", str(local))
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+
+        msix_cfg = None
+        if with_msix_candidate:
+            claude_dir = (
+                local
+                / "Packages"
+                / "Claude_pzs8sxrjxfjjc"
+                / "LocalCache"
+                / "Roaming"
+                / "Claude"
+            )
+            claude_dir.mkdir(parents=True)
+            msix_cfg = claude_dir / "claude_desktop_config.json"
+
+        fake_proxy = tmp_path / "bin" / "mcp-proxy"
+        fake_proxy.parent.mkdir()
+        fake_proxy.touch()
+        fake_python = tmp_path / "bin" / "python"
+        monkeypatch.setattr("cdcasasagi.mcp_proxy.sys.executable", str(fake_python))
+
+        return appdata_cfg, msix_cfg
+
+    def test_msix_warn_when_appdata_path(self, monkeypatch, tmp_path):
+        _, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[WARN] Claude Desktop MSIX path:" in result.output
+        assert str(msix_cfg) in result.output
+        assert "CLAUDE_DESKTOP_CONFIG=" in result.output
+
+    def test_msix_no_warn_when_env_var_set(self, monkeypatch, tmp_path):
+        _, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        monkeypatch.setenv("CLAUDE_DESKTOP_CONFIG", str(msix_cfg))
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[WARN]" not in result.output
+
+    def test_msix_no_warn_when_no_candidates(self, monkeypatch, tmp_path):
+        self._setup_windows_doctor(monkeypatch, tmp_path, with_msix_candidate=False)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[WARN]" not in result.output
+
+    def test_doctor_exits_zero_with_only_warnings(self, monkeypatch, tmp_path):
+        self._setup_windows_doctor(monkeypatch, tmp_path)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[FAIL]" not in result.output
+        assert "All checks passed (1 warning)." in result.output
+
 
 class TestList:
     def test_lists_entries_alphabetically(self, config_env):

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -14,6 +14,7 @@ from cdcasasagi.desktop_config import (
     build_entry,
     config_path,
     list_mcp_proxy_entries,
+    windows_msix_config_candidates,
     load_backup,
     load_config,
     merge_entry,
@@ -47,6 +48,93 @@ class TestConfigPath:
         monkeypatch.setenv("APPDATA", "/fake/appdata")
         result = config_path()
         assert result == Path("/fake/appdata/Claude/claude_desktop_config.json")
+
+
+class TestWindowsMsixConfigCandidates:
+    def _setup_windows(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "cdcasasagi.desktop_config.platform.system", lambda: "Windows"
+        )
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+    def test_non_windows(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "cdcasasagi.desktop_config.platform.system", lambda: "Darwin"
+        )
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+        assert windows_msix_config_candidates() == []
+
+    def test_no_localappdata(self, monkeypatch):
+        monkeypatch.setattr(
+            "cdcasasagi.desktop_config.platform.system", lambda: "Windows"
+        )
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        assert windows_msix_config_candidates() == []
+
+    def test_no_packages_dir(self, monkeypatch, tmp_path):
+        self._setup_windows(monkeypatch, tmp_path)
+        assert windows_msix_config_candidates() == []
+
+    def test_one_match_dir_only(self, monkeypatch, tmp_path):
+        self._setup_windows(monkeypatch, tmp_path)
+        claude_dir = (
+            tmp_path
+            / "Packages"
+            / "Claude_pzs8sxrjxfjjc"
+            / "LocalCache"
+            / "Roaming"
+            / "Claude"
+        )
+        claude_dir.mkdir(parents=True)
+        result = windows_msix_config_candidates()
+        assert result == [claude_dir / "claude_desktop_config.json"]
+
+    def test_one_match_file_exists(self, monkeypatch, tmp_path):
+        self._setup_windows(monkeypatch, tmp_path)
+        claude_dir = (
+            tmp_path
+            / "Packages"
+            / "Claude_pzs8sxrjxfjjc"
+            / "LocalCache"
+            / "Roaming"
+            / "Claude"
+        )
+        claude_dir.mkdir(parents=True)
+        cfg = claude_dir / "claude_desktop_config.json"
+        cfg.write_text("{}")
+        assert windows_msix_config_candidates() == [cfg]
+
+    def test_two_matches_sorted(self, monkeypatch, tmp_path):
+        self._setup_windows(monkeypatch, tmp_path)
+        a = (
+            tmp_path
+            / "Packages"
+            / "Anthropic.ClaudeDesktop_h6f0761"
+            / "LocalCache"
+            / "Roaming"
+            / "Claude"
+        )
+        b = (
+            tmp_path
+            / "Packages"
+            / "Claude_pzs8sxrjxfjjc"
+            / "LocalCache"
+            / "Roaming"
+            / "Claude"
+        )
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+        result = windows_msix_config_candidates()
+        assert result == [
+            a / "claude_desktop_config.json",
+            b / "claude_desktop_config.json",
+        ]
+
+    def test_match_without_claude_dir_excluded(self, monkeypatch, tmp_path):
+        self._setup_windows(monkeypatch, tmp_path)
+        # Package matches but LocalCache\Roaming\Claude doesn't exist
+        (tmp_path / "Packages" / "Claude_xyz").mkdir(parents=True)
+        assert windows_msix_config_candidates() == []
 
 
 class TestBackupPath:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -318,9 +318,9 @@ class TestImportWriteMessage:
 class TestDoctorMessage:
     def test_all_pass(self):
         results = [
-            ("mcp-proxy", True, "/usr/local/bin/mcp-proxy"),
-            ("Config file", True, "/tmp/config.json"),
-            ("Config directory", True, "/tmp"),
+            ("mcp-proxy", "pass", "/usr/local/bin/mcp-proxy"),
+            ("Config file", "pass", "/tmp/config.json"),
+            ("Config directory", "pass", "/tmp"),
         ]
         msg = doctor_message(results)
         assert msg.count("[PASS]") == 3
@@ -329,9 +329,9 @@ class TestDoctorMessage:
 
     def test_one_failure(self):
         results = [
-            ("mcp-proxy", True, "/usr/local/bin/mcp-proxy"),
-            ("Config file", False, "not found: /tmp/config.json"),
-            ("Config directory", True, "/tmp"),
+            ("mcp-proxy", "pass", "/usr/local/bin/mcp-proxy"),
+            ("Config file", "fail", "not found: /tmp/config.json"),
+            ("Config directory", "pass", "/tmp"),
         ]
         msg = doctor_message(results)
         assert msg.count("[PASS]") == 2
@@ -340,9 +340,9 @@ class TestDoctorMessage:
 
     def test_multiple_failures(self):
         results = [
-            ("mcp-proxy", False, "not found"),
-            ("Config file", False, "not found: /tmp/config.json"),
-            ("Config directory", False, "not writable: /tmp"),
+            ("mcp-proxy", "fail", "not found"),
+            ("Config file", "fail", "not found: /tmp/config.json"),
+            ("Config directory", "fail", "not writable: /tmp"),
         ]
         msg = doctor_message(results)
         assert msg.count("[FAIL]") == 3
@@ -350,19 +350,46 @@ class TestDoctorMessage:
 
     def test_detail_shown(self):
         results = [
-            ("mcp-proxy", True, "/path/to/mcp-proxy"),
+            ("mcp-proxy", "pass", "/path/to/mcp-proxy"),
         ]
         msg = doctor_message(results)
         assert "/path/to/mcp-proxy" in msg
 
     def test_ascii_only(self):
         results = [
-            ("mcp-proxy", True, "/usr/local/bin/mcp-proxy"),
-            ("Config file", False, "not found: /tmp/config.json"),
-            ("Config directory", True, "/tmp"),
+            ("mcp-proxy", "pass", "/usr/local/bin/mcp-proxy"),
+            ("Config file", "fail", "not found: /tmp/config.json"),
+            ("Config directory", "pass", "/tmp"),
         ]
         msg = doctor_message(results)
         assert msg.isascii()
+
+    def test_warn_renders_warn_tag(self):
+        results = [
+            ("mcp-proxy", "pass", "/usr/local/bin/mcp-proxy"),
+            ("Claude Desktop MSIX path", "warn", "see candidates"),
+        ]
+        msg = doctor_message(results)
+        assert "[WARN] Claude Desktop MSIX path:" in msg
+
+    def test_warn_counted_separately_from_failures(self):
+        results = [
+            ("mcp-proxy", "pass", "/usr/local/bin/mcp-proxy"),
+            ("Config file", "pass", "/tmp/config.json"),
+            ("Config directory", "pass", "/tmp"),
+            ("Claude Desktop MSIX path", "warn", "see candidates"),
+        ]
+        msg = doctor_message(results)
+        assert "[FAIL]" not in msg
+        assert "All checks passed (1 warning)." in msg
+
+    def test_multiple_warnings(self):
+        results = [
+            ("a", "warn", "x"),
+            ("b", "warn", "y"),
+        ]
+        msg = doctor_message(results)
+        assert "All checks passed (2 warnings)." in msg
 
 
 class TestListMessage:


### PR DESCRIPTION
## Summary

Stage 1 of #50: `doctor` now detects when Claude Desktop is installed via MSIX (Windows) and the active config path diverges from the virtualized path that the app actually reads.

- Adds `desktop_config.windows_msix_config_candidates()` — globs `%LOCALAPPDATA%\Packages\*Claude*\LocalCache\Roaming\Claude\claude_desktop_config.json` and returns matches sorted. Empty on non-Windows / missing `%LOCALAPPDATA%` / no match.
- `doctor` emits a `[WARN]` row when `CLAUDE_DESKTOP_CONFIG` is unset, the resolved `cfg_path` is not under `%LOCALAPPDATA%\Packages\`, and at least one MSIX candidate exists. The row lists candidates and the recommended `CLAUDE_DESKTOP_CONFIG=<path>` to export, with a caveat that `Settings > Developer > Edit Config` may itself open the wrong path on MSIX (anthropics/claude-code#26073).
- `doctor_message` accepts `(label, "pass"|"fail"|"warn", detail)`; `[WARN]` rows count as warnings, not failures. Exit code stays 0 when only warnings are present, with summary `All checks passed (1 warning).`.

Write-path behavior of `add` / `import` is unchanged — Stage 2 will auto-fall-back.

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` (238 passed)
- [ ] Manual smoke on a Windows MSIX install (per issue verification steps)

Closes #50.