### PR TITLE
config_path: auto-fall back to Windows MSIX virtualized path

### DIFF
--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -38,22 +38,26 @@ def doctor() -> None:
     except mcp_proxy.McpProxyNotFoundError:
         results.append(("mcp-proxy", "fail", "not found"))
 
-    cfg_path = desktop_config.config_path()
-    if cfg_path.is_file():
-        results.append(("Config file", "pass", str(cfg_path)))
+    try:
+        cfg_path = desktop_config.config_path()
+    except desktop_config.AmbiguousConfigError as e:
+        results.append(("Config file", "fail", str(e)))
     else:
-        results.append(("Config file", "fail", f"not found: {cfg_path}"))
+        if cfg_path.is_file():
+            results.append(("Config file", "pass", str(cfg_path)))
+        else:
+            results.append(("Config file", "fail", f"not found: {cfg_path}"))
 
-    cfg_dir = cfg_path.parent
-    if os.access(cfg_dir, os.W_OK):
-        results.append(("Config directory", "pass", str(cfg_dir)))
-    else:
-        results.append(("Config directory", "fail", f"not writable: {cfg_dir}"))
+        cfg_dir = cfg_path.parent
+        if os.access(cfg_dir, os.W_OK):
+            results.append(("Config directory", "pass", str(cfg_dir)))
+        else:
+            results.append(("Config directory", "fail", f"not writable: {cfg_dir}"))
 
-    if _platform.system() == "Windows":
-        msix_row = _msix_doctor_row(cfg_path)
-        if msix_row is not None:
-            results.append(msix_row)
+        if _platform.system() == "Windows":
+            msix_row = _msix_doctor_row(cfg_path)
+            if msix_row is not None:
+                results.append(msix_row)
 
     typer.echo(output.doctor_message(results))
     if any(status == "fail" for _, status, _ in results):
@@ -61,8 +65,6 @@ def doctor() -> None:
 
 
 def _msix_doctor_row(cfg_path: Path) -> tuple[str, str, str] | None:
-    if os.environ.get("CLAUDE_DESKTOP_CONFIG"):
-        return None
     local = os.environ.get("LOCALAPPDATA", "")
     if local:
         try:
@@ -73,31 +75,18 @@ def _msix_doctor_row(cfg_path: Path) -> tuple[str, str, str] | None:
     candidates = desktop_config.windows_msix_config_candidates()
     if not candidates:
         return None
-    lines = [
+    detail = desktop_config.format_msix_guidance(
         "Claude Desktop on MSIX reads config from a virtualized path.",
-        "Candidate path(s):",
-    ]
-    for c in candidates:
-        lines.append(f"  {c}")
-    lines.append("")
-    lines.append("Set CLAUDE_DESKTOP_CONFIG to the path Claude Desktop actually reads:")
-    lines.append(f"  CLAUDE_DESKTOP_CONFIG={candidates[0]}")
-    lines.append("")
-    lines.append(
-        "Confirm via Claude Desktop: Settings > Developer > Edit Config; the "
-        "editor's title bar shows the path. On MSIX installs Edit Config may "
-        "itself open the wrong (%APPDATA%) path "
-        "(see anthropics/claude-code#26073), so cross-check against the "
-        "candidate list above."
+        candidates,
     )
-    return ("Claude Desktop MSIX path", "warn", "\n".join(lines))
+    return ("Claude Desktop MSIX path", "warn", detail)
 
 
 @app.command(name="list")
 def list_cmd() -> None:
     """List cdcasasagi-managed MCP servers as 'name : url'."""
-    cfg_path = desktop_config.config_path()
     try:
+        cfg_path = desktop_config.config_path()
         config = desktop_config.load_config(cfg_path)
     except desktop_config.ConfigError as e:
         typer.echo(str(e), err=True)
@@ -143,9 +132,8 @@ def add(
         typer.echo(str(e), err=True)
         raise typer.Exit(code=1)
 
-    cfg_path = desktop_config.config_path()
-
     try:
+        cfg_path = desktop_config.config_path()
         current_config = desktop_config.load_config(cfg_path)
     except desktop_config.ConfigError as e:
         typer.echo(str(e), err=True)
@@ -177,9 +165,8 @@ def delete(
     url: str = typer.Argument(..., help="URL of the mcpServers entry to remove"),
     write: bool = typer.Option(False, help="Actually write to the file"),
 ) -> None:
-    cfg_path = desktop_config.config_path()
-
     try:
+        cfg_path = desktop_config.config_path()
         current_config = desktop_config.load_config(cfg_path)
     except desktop_config.ConfigError as e:
         typer.echo(str(e), err=True)
@@ -201,7 +188,11 @@ def delete(
 
 @app.command()
 def revert() -> None:
-    cfg_path = desktop_config.config_path()
+    try:
+        cfg_path = desktop_config.config_path()
+    except desktop_config.ConfigError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(code=1)
 
     try:
         backup_config = desktop_config.load_backup(cfg_path)
@@ -467,8 +458,8 @@ def import_cmd(
 
     resolved = _resolve_import_entries(raw_entries, proxy_path)
 
-    cfg_path = desktop_config.config_path()
     try:
+        cfg_path = desktop_config.config_path()
         current_config = desktop_config.load_config(cfg_path)
     except desktop_config.ConfigError as e:
         typer.echo(str(e), err=True)

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -13,6 +13,10 @@ class ConfigError(Exception):
     pass
 
 
+class AmbiguousConfigError(ConfigError):
+    pass
+
+
 class EntryExistsError(Exception):
     pass
 
@@ -39,7 +43,21 @@ def config_path() -> Path:
         return Path(env)
     if platform.system() == "Windows":
         appdata = os.environ.get("APPDATA", "")
-        return Path(appdata) / "Claude" / "claude_desktop_config.json"
+        appdata_path = Path(appdata) / "Claude" / "claude_desktop_config.json"
+        candidates = windows_msix_config_candidates()
+        if not candidates:
+            return appdata_path
+        if len(candidates) == 1:
+            return candidates[0]
+        existing = [c for c in candidates if c.is_file()]
+        if len(existing) == 1:
+            return existing[0]
+        raise AmbiguousConfigError(
+            format_msix_guidance(
+                "Multiple Claude Desktop MSIX packages were detected.",
+                candidates,
+            )
+        )
     return (
         Path.home()
         / "Library"
@@ -47,6 +65,26 @@ def config_path() -> Path:
         / "Claude"
         / "claude_desktop_config.json"
     )
+
+
+def format_msix_guidance(header: str, candidates: list[Path]) -> str:
+    lines = [header, "Candidate path(s):"]
+    for c in candidates:
+        lines.append(f"  {c}")
+    lines.append("")
+    lines.append(
+        "Set CLAUDE_DESKTOP_CONFIG to the path Claude Desktop is actually using:"
+    )
+    lines.append(f"  CLAUDE_DESKTOP_CONFIG={candidates[0]}")
+    lines.append("")
+    lines.append(
+        "Confirm via Claude Desktop: Settings > Developer > Edit Config; the "
+        "editor's title bar shows the path. On MSIX installs Edit Config may "
+        "itself open the wrong (%APPDATA%) path "
+        "(see anthropics/claude-code#26073), so cross-check against the "
+        "candidate list above."
+    )
+    return "\n".join(lines)
 
 
 def windows_msix_config_candidates() -> list[Path]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -124,21 +124,34 @@ class TestDoctor:
 
         return appdata_cfg, msix_cfg
 
-    def test_msix_warn_when_appdata_path(self, monkeypatch, tmp_path):
-        _, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+    def test_msix_warn_when_env_pins_appdata_path(self, monkeypatch, tmp_path):
+        """User explicitly set CLAUDE_DESKTOP_CONFIG to %APPDATA%\\... despite
+        an MSIX candidate existing — the WARN row should still fire.
+        """
+        appdata_cfg, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        monkeypatch.setenv("CLAUDE_DESKTOP_CONFIG", str(appdata_cfg))
         result = runner.invoke(app, ["doctor"])
         assert result.exit_code == 0
         assert "[WARN] Claude Desktop MSIX path:" in result.output
         assert str(msix_cfg) in result.output
         assert "CLAUDE_DESKTOP_CONFIG=" in result.output
 
-    def test_msix_no_warn_when_env_var_set(self, monkeypatch, tmp_path):
+    def test_msix_no_warn_when_env_var_set_to_msix(self, monkeypatch, tmp_path):
         _, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
         msix_cfg.write_text('{"mcpServers": {}}')
         monkeypatch.setenv("CLAUDE_DESKTOP_CONFIG", str(msix_cfg))
         result = runner.invoke(app, ["doctor"])
         assert result.exit_code == 0
         assert "[WARN]" not in result.output
+
+    def test_msix_auto_selected_no_warn(self, monkeypatch, tmp_path):
+        """Single MSIX candidate -> config_path() auto-selects it, no WARN."""
+        _, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[WARN]" not in result.output
+        assert str(msix_cfg) in result.output
 
     def test_msix_no_warn_when_no_candidates(self, monkeypatch, tmp_path):
         self._setup_windows_doctor(monkeypatch, tmp_path, with_msix_candidate=False)
@@ -147,11 +160,74 @@ class TestDoctor:
         assert "[WARN]" not in result.output
 
     def test_doctor_exits_zero_with_only_warnings(self, monkeypatch, tmp_path):
-        self._setup_windows_doctor(monkeypatch, tmp_path)
+        appdata_cfg, _ = self._setup_windows_doctor(monkeypatch, tmp_path)
+        monkeypatch.setenv("CLAUDE_DESKTOP_CONFIG", str(appdata_cfg))
         result = runner.invoke(app, ["doctor"])
         assert result.exit_code == 0
         assert "[FAIL]" not in result.output
         assert "All checks passed (1 warning)." in result.output
+
+
+class TestAmbiguousMsixConfig:
+    """`config_path()` raises AmbiguousConfigError when multiple MSIX packages
+    each have a config file. Verify each command surfaces the error message
+    and the doctor still runs the mcp-proxy check.
+    """
+
+    def _setup(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("CLAUDE_DESKTOP_CONFIG", raising=False)
+        appdata = tmp_path / "appdata"
+        local = tmp_path / "local"
+        appdata.mkdir()
+        local.mkdir()
+        monkeypatch.setenv("APPDATA", str(appdata))
+        monkeypatch.setenv("LOCALAPPDATA", str(local))
+        monkeypatch.setattr("platform.system", lambda: "Windows")
+        monkeypatch.setattr(
+            "cdcasasagi.desktop_config.platform.system", lambda: "Windows"
+        )
+        cfgs = []
+        for pkg in ("Anthropic.ClaudeDesktop_h6f0761", "Claude_pzs8sxrjxfjjc"):
+            d = local / "Packages" / pkg / "LocalCache" / "Roaming" / "Claude"
+            d.mkdir(parents=True)
+            cfg = d / "claude_desktop_config.json"
+            cfg.write_text('{"mcpServers": {}}')
+            cfgs.append(cfg)
+        fake_proxy = tmp_path / "bin" / "mcp-proxy"
+        fake_proxy.parent.mkdir()
+        fake_proxy.touch()
+        fake_python = tmp_path / "bin" / "python"
+        monkeypatch.setattr("cdcasasagi.mcp_proxy.sys.executable", str(fake_python))
+        return cfgs
+
+    def test_doctor_reports_fail_and_continues(self, monkeypatch, tmp_path):
+        cfgs = self._setup(monkeypatch, tmp_path)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 1
+        assert "[FAIL] Config file:" in result.output
+        for cfg in cfgs:
+            assert str(cfg) in result.output
+        assert "CLAUDE_DESKTOP_CONFIG" in result.output
+        # mcp-proxy check still ran
+        assert "[PASS] mcp-proxy:" in result.output
+
+    def test_add_exits_with_env_var_hint(self, monkeypatch, tmp_path):
+        cfgs = self._setup(monkeypatch, tmp_path)
+        result = runner.invoke(app, ["add", "https://mcp.notion.com/mcp"])
+        assert result.exit_code == 1
+        assert "CLAUDE_DESKTOP_CONFIG" in result.output
+        for cfg in cfgs:
+            assert str(cfg) in result.output
+
+    def test_import_exits_with_env_var_hint(self, monkeypatch, tmp_path):
+        cfgs = self._setup(monkeypatch, tmp_path)
+        input_file = tmp_path / "servers.jsonl"
+        input_file.write_text('{"url": "https://mcp.notion.com/mcp"}\n')
+        result = runner.invoke(app, ["import", str(input_file)])
+        assert result.exit_code == 1
+        assert "CLAUDE_DESKTOP_CONFIG" in result.output
+        for cfg in cfgs:
+            assert str(cfg) in result.output
 
 
 class TestList:

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from cdcasasagi.desktop_config import (
+    AmbiguousConfigError,
     BackupError,
     BackupNotFoundError,
     ConfigError,
@@ -48,6 +49,80 @@ class TestConfigPath:
         monkeypatch.setenv("APPDATA", "/fake/appdata")
         result = config_path()
         assert result == Path("/fake/appdata/Claude/claude_desktop_config.json")
+
+    def _setup_windows_msix(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("CLAUDE_DESKTOP_CONFIG", raising=False)
+        monkeypatch.setattr(
+            "cdcasasagi.desktop_config.platform.system", lambda: "Windows"
+        )
+        appdata = tmp_path / "appdata"
+        local = tmp_path / "local"
+        appdata.mkdir()
+        local.mkdir()
+        monkeypatch.setenv("APPDATA", str(appdata))
+        monkeypatch.setenv("LOCALAPPDATA", str(local))
+        return appdata, local
+
+    def _make_msix_dir(self, local: Path, pkg: str) -> Path:
+        d = local / "Packages" / pkg / "LocalCache" / "Roaming" / "Claude"
+        d.mkdir(parents=True)
+        return d / "claude_desktop_config.json"
+
+    def test_windows_no_msix_candidates(self, monkeypatch, tmp_path):
+        appdata, _ = self._setup_windows_msix(monkeypatch, tmp_path)
+        assert config_path() == appdata / "Claude" / "claude_desktop_config.json"
+
+    def test_windows_one_msix_candidate_file_missing(self, monkeypatch, tmp_path):
+        _, local = self._setup_windows_msix(monkeypatch, tmp_path)
+        cfg = self._make_msix_dir(local, "Claude_pzs8sxrjxfjjc")
+        assert config_path() == cfg
+
+    def test_windows_one_msix_candidate_file_exists(self, monkeypatch, tmp_path):
+        _, local = self._setup_windows_msix(monkeypatch, tmp_path)
+        cfg = self._make_msix_dir(local, "Claude_pzs8sxrjxfjjc")
+        cfg.write_text("{}")
+        assert config_path() == cfg
+
+    def test_windows_two_candidates_one_file_exists(self, monkeypatch, tmp_path):
+        _, local = self._setup_windows_msix(monkeypatch, tmp_path)
+        a = self._make_msix_dir(local, "Anthropic.ClaudeDesktop_h6f0761")
+        b = self._make_msix_dir(local, "Claude_pzs8sxrjxfjjc")
+        b.write_text("{}")
+        # Only b has a real file; a is just the directory.
+        assert not a.exists()
+        assert config_path() == b
+
+    def test_windows_two_candidates_no_files_exist(self, monkeypatch, tmp_path):
+        _, local = self._setup_windows_msix(monkeypatch, tmp_path)
+        a = self._make_msix_dir(local, "Anthropic.ClaudeDesktop_h6f0761")
+        b = self._make_msix_dir(local, "Claude_pzs8sxrjxfjjc")
+        with pytest.raises(AmbiguousConfigError) as exc:
+            config_path()
+        msg = str(exc.value)
+        assert str(a) in msg
+        assert str(b) in msg
+        assert "CLAUDE_DESKTOP_CONFIG" in msg
+
+    def test_windows_two_candidates_both_files_exist(self, monkeypatch, tmp_path):
+        _, local = self._setup_windows_msix(monkeypatch, tmp_path)
+        a = self._make_msix_dir(local, "Anthropic.ClaudeDesktop_h6f0761")
+        b = self._make_msix_dir(local, "Claude_pzs8sxrjxfjjc")
+        a.write_text("{}")
+        b.write_text("{}")
+        with pytest.raises(AmbiguousConfigError) as exc:
+            config_path()
+        msg = str(exc.value)
+        assert str(a) in msg
+        assert str(b) in msg
+        assert "CLAUDE_DESKTOP_CONFIG" in msg
+
+    def test_env_override_wins_over_msix(self, monkeypatch, tmp_path):
+        _, local = self._setup_windows_msix(monkeypatch, tmp_path)
+        self._make_msix_dir(local, "Anthropic.ClaudeDesktop_h6f0761")
+        self._make_msix_dir(local, "Claude_pzs8sxrjxfjjc")
+        override = tmp_path / "custom.json"
+        monkeypatch.setenv("CLAUDE_DESKTOP_CONFIG", str(override))
+        assert config_path() == override
 
 
 class TestWindowsMsixConfigCandidates:


### PR DESCRIPTION
## Summary

Stage 2 of the MSIX virtualized-path fix (#51, follow-up to #50).

`config_path()` now auto-resolves to the MSIX virtualized config path on Windows when one is detected, so all commands (`add`, `import`, `delete`, `list`, `revert`, `doctor`) target the file Claude Desktop actually reads — no `CLAUDE_DESKTOP_CONFIG` env var needed.

Resolution order on Windows:

- `CLAUDE_DESKTOP_CONFIG` set -> use it (existing).
- 0 MSIX candidates -> `%APPDATA%\Claude\...` (legacy / non-MSIX).
- 1 MSIX candidate -> use it.
- >1 candidates, exactly 1 has the file on disk -> use it.
- Otherwise -> raise `AmbiguousConfigError` with the candidate list and guidance to set `CLAUDE_DESKTOP_CONFIG`.

`AmbiguousConfigError` extends `ConfigError`, so existing `except ConfigError` blocks at command call sites surface it naturally; `config_path()` calls in `add`, `delete`, `list`, `revert`, `import` are now covered by a try/except. `doctor` reports the error as a `[FAIL]` Config-file row and continues running the `mcp-proxy` check.

The Stage 1 WARN row now fires only when the user has explicitly pinned `CLAUDE_DESKTOP_CONFIG` to `%APPDATA%\...` despite an MSIX candidate existing — the env-var early-return in `_msix_doctor_row` was removed and the surviving rare case is the only one that triggers the row.

The guidance text shared between the `AmbiguousConfigError` message and the doctor WARN row is now produced by `desktop_config.format_msix_guidance`.

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` (249 passed)
- [x] New `TestConfigPath` cases cover the full decision tree (0 / 1-no-file / 1-with-file / 2-one-file / 2-no-files / 2-both-files / env-override).
- [x] `TestAmbiguousMsixConfig` exercises `doctor`, `add`, `import` against ambiguous candidates.
- [ ] Manual smoke on Windows MSIX (out of scope for CI per the issue — same reasoning as #50).

Closes #51