### PR TITLE
doctor: warn about orphan %APPDATA%\Claude config (#53)

### DIFF
--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -95,10 +95,12 @@ def _orphan_appdata_doctor_row(cfg_path: Path) -> tuple[str, str, str] | None:
         return None
 
     appdata_path = desktop_config.appdata_config_path()
-    if appdata_path is None or not appdata_path.is_file():
+    if appdata_path is None:
         return None
 
     try:
+        if not appdata_path.is_file():
+            return None
         config = desktop_config.load_config(appdata_path)
     except (desktop_config.ConfigError, OSError):
         detail = (

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -58,6 +58,9 @@ def doctor() -> None:
             msix_row = _msix_doctor_row(cfg_path)
             if msix_row is not None:
                 results.append(msix_row)
+            orphan_row = _orphan_appdata_doctor_row(cfg_path)
+            if orphan_row is not None:
+                results.append(orphan_row)
 
     typer.echo(output.doctor_message(results))
     if any(status == "fail" for _, status, _ in results):
@@ -80,6 +83,45 @@ def _msix_doctor_row(cfg_path: Path) -> tuple[str, str, str] | None:
         candidates,
     )
     return ("Claude Desktop MSIX path", "warn", detail)
+
+
+def _orphan_appdata_doctor_row(cfg_path: Path) -> tuple[str, str, str] | None:
+    local = os.environ.get("LOCALAPPDATA", "")
+    if not local:
+        return None
+    try:
+        cfg_path.resolve().relative_to((Path(local) / "Packages").resolve())
+    except ValueError:
+        return None
+
+    appdata_path = desktop_config.appdata_config_path()
+    if appdata_path is None or not appdata_path.is_file():
+        return None
+
+    try:
+        config = desktop_config.load_config(appdata_path)
+    except desktop_config.ConfigError:
+        detail = (
+            f"Orphan config at {appdata_path} is present but unreadable.\n"
+            f"Active config: {cfg_path}\n"
+            "Claude Desktop reads only the active config. Inspect the orphan "
+            "file manually, then delete it once you have migrated any entries."
+        )
+        return ("Orphan APPDATA config", "warn", detail)
+
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict) or not servers:
+        return None
+
+    names = ", ".join(sorted(servers.keys()))
+    detail = (
+        f"Orphan config at {appdata_path} has mcpServers entries: {names}\n"
+        f"Active config: {cfg_path} (Claude Desktop reads only this file).\n"
+        "Re-add the entries against the active config "
+        "(`cdcasasagi add ...` or `cdcasasagi import ...`), "
+        "then delete the orphan file."
+    )
+    return ("Orphan APPDATA config", "warn", detail)
 
 
 @app.command(name="list")

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -100,7 +100,7 @@ def _orphan_appdata_doctor_row(cfg_path: Path) -> tuple[str, str, str] | None:
 
     try:
         config = desktop_config.load_config(appdata_path)
-    except desktop_config.ConfigError:
+    except (desktop_config.ConfigError, OSError):
         detail = (
             f"Orphan config at {appdata_path} is present but unreadable.\n"
             f"Active config: {cfg_path}\n"

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -87,6 +87,16 @@ def format_msix_guidance(header: str, candidates: list[Path]) -> str:
     return "\n".join(lines)
 
 
+def appdata_config_path() -> Path | None:
+    """Return ``%APPDATA%\\Claude\\claude_desktop_config.json`` on Windows, else None."""
+    if platform.system() != "Windows":
+        return None
+    appdata = os.environ.get("APPDATA", "")
+    if not appdata:
+        return None
+    return Path(appdata) / "Claude" / "claude_desktop_config.json"
+
+
 def windows_msix_config_candidates() -> list[Path]:
     """Return claude_desktop_config.json paths under the MSIX virtualized
     Packages directory, sorted for determinism. Empty list on non-Windows,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -239,6 +239,24 @@ class TestDoctor:
         assert "[WARN] Orphan APPDATA config:" in result.output
         assert "unreadable" in result.output
 
+    def test_orphan_warn_when_stat_raises_oserror(self, monkeypatch, tmp_path):
+        appdata_cfg, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        appdata_cfg.write_text('{"mcpServers": {}}')
+
+        original_is_file = type(appdata_cfg).is_file
+
+        def fake_is_file(self, *args, **kwargs):
+            if self == appdata_cfg:
+                raise PermissionError("ACL blocks stat")
+            return original_is_file(self, *args, **kwargs)
+
+        monkeypatch.setattr(type(appdata_cfg), "is_file", fake_is_file)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[WARN] Orphan APPDATA config:" in result.output
+        assert "unreadable" in result.output
+
     def test_orphan_no_warn_when_non_msix_install(self, monkeypatch, tmp_path):
         appdata_cfg, _ = self._setup_windows_doctor(
             monkeypatch, tmp_path, with_msix_candidate=False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,6 +167,81 @@ class TestDoctor:
         assert "[FAIL]" not in result.output
         assert "All checks passed (1 warning)." in result.output
 
+    def test_orphan_no_warn_when_file_absent(self, monkeypatch, tmp_path):
+        appdata_cfg, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        appdata_cfg.unlink()
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "Orphan APPDATA config" not in result.output
+
+    def test_orphan_warn_lists_entries_and_active_path(self, monkeypatch, tmp_path):
+        appdata_cfg, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        appdata_cfg.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": {"command": "x", "args": []},
+                        "github": {"command": "y", "args": []},
+                    }
+                }
+            )
+        )
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[WARN] Orphan APPDATA config:" in result.output
+        assert str(appdata_cfg) in result.output
+        assert "github, notion" in result.output
+        assert str(msix_cfg) in result.output
+
+    def test_orphan_no_warn_when_mcp_servers_empty(self, monkeypatch, tmp_path):
+        appdata_cfg, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        appdata_cfg.write_text('{"mcpServers": {}}')
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "Orphan APPDATA config" not in result.output
+
+    def test_orphan_no_warn_when_mcp_servers_key_missing(self, monkeypatch, tmp_path):
+        appdata_cfg, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        appdata_cfg.write_text("{}")
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "Orphan APPDATA config" not in result.output
+
+    def test_orphan_warn_when_unreadable(self, monkeypatch, tmp_path):
+        appdata_cfg, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        appdata_cfg.write_text("not json {")
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[WARN] Orphan APPDATA config:" in result.output
+        assert "unreadable" in result.output
+        assert str(appdata_cfg) in result.output
+
+    def test_orphan_no_warn_when_non_msix_install(self, monkeypatch, tmp_path):
+        appdata_cfg, _ = self._setup_windows_doctor(
+            monkeypatch, tmp_path, with_msix_candidate=False
+        )
+        appdata_cfg.write_text(
+            json.dumps({"mcpServers": {"notion": {"command": "x", "args": []}}})
+        )
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "Orphan APPDATA config" not in result.output
+
+    def test_orphan_no_warn_when_env_pins_appdata(self, monkeypatch, tmp_path):
+        appdata_cfg, _ = self._setup_windows_doctor(monkeypatch, tmp_path)
+        appdata_cfg.write_text(
+            json.dumps({"mcpServers": {"notion": {"command": "x", "args": []}}})
+        )
+        monkeypatch.setenv("CLAUDE_DESKTOP_CONFIG", str(appdata_cfg))
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "Orphan APPDATA config" not in result.output
+
 
 class TestAmbiguousMsixConfig:
     """`config_path()` raises AmbiguousConfigError when multiple MSIX packages

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -221,6 +221,24 @@ class TestDoctor:
         assert "unreadable" in result.output
         assert str(appdata_cfg) in result.output
 
+    def test_orphan_warn_when_read_raises_oserror(self, monkeypatch, tmp_path):
+        appdata_cfg, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        appdata_cfg.write_text('{"mcpServers": {}}')
+
+        original_read_text = type(appdata_cfg).read_text
+
+        def fake_read_text(self, *args, **kwargs):
+            if self == appdata_cfg:
+                raise PermissionError("locked")
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(type(appdata_cfg), "read_text", fake_read_text)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[WARN] Orphan APPDATA config:" in result.output
+        assert "unreadable" in result.output
+
     def test_orphan_no_warn_when_non_msix_install(self, monkeypatch, tmp_path):
         appdata_cfg, _ = self._setup_windows_doctor(
             monkeypatch, tmp_path, with_msix_candidate=False


### PR DESCRIPTION
## Summary
- On Windows MSIX installs, `doctor` now emits a `[WARN]` row when `%APPDATA%\Claude\claude_desktop_config.json` exists alongside the active MSIX-virtualized config and contains stranded `mcpServers` entries (or is unparseable). The warn lists the orphan entry names and points users to re-add them against the active path before deleting the orphan file.
- New `desktop_config.appdata_config_path()` helper returns the legacy path on Windows.
- The orphan check is informational and never flips exit code (consistent with #50).

Closes #53

## Test plan
- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` (256 passed)
- [x] New unit tests cover: orphan absent, orphan with non-empty mcpServers, empty `{}`, missing key, invalid JSON, non-MSIX install, and `CLAUDE_DESKTOP_CONFIG` pinned to APPDATA.

https://claude.ai/code/session_01RU7AZANiH5DnCrkPFrsCtp