### PR TITLE
docs: Document doctor command and Windows MSIX behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ This reports the resolved `mcp-proxy` binary, the active Claude Desktop config p
 
 On Windows, `doctor` also surfaces two MSIX-specific warnings:
 
-- **Claude Desktop MSIX path** — the active config lives under the MSIX virtualized path (`%LOCALAPPDATA%\Packages\...\LocalCache\Roaming\Claude\...`). cdcasasagi reads and writes that path automatically; the warning is informational.
-- **Orphan APPDATA config** — a leftover `%APPDATA%\Claude\claude_desktop_config.json` is present alongside the MSIX-virtualized active config. Claude Desktop reads only the active file, so any `mcpServers` entries in the orphan are ignored. Re-add them against the active config, then delete the orphan.
+- **Claude Desktop MSIX path** — the active config is **not** under the MSIX virtualized path, but a Claude MSIX install was detected. Claude Desktop on MSIX reads from the virtualized path (`%LOCALAPPDATA%\Packages\...\LocalCache\Roaming\Claude\...`), so edits to the current path may have no effect. Set `CLAUDE_DESKTOP_CONFIG` to the candidate path shown in the warning.
+- **Orphan APPDATA config** — the active config is on the MSIX virtualized path, and a leftover `%APPDATA%\Claude\claude_desktop_config.json` is also present. Claude Desktop reads only the active file, so any `mcpServers` entries in the orphan are ignored. Re-add them against the active config, then delete the orphan.
 
 ### revert
 
@@ -177,5 +177,5 @@ When multiple MSIX package directories are detected, cdcasasagi first tries to d
 
 Run `cdcasasagi doctor` to check the resolved config path. On Windows it also surfaces two MSIX-specific situations:
 
-- The active config is on the MSIX virtualized path (informational — cdcasasagi handles it automatically).
+- The active config is on `%APPDATA%` while a Claude MSIX install is detected. Claude Desktop on MSIX reads the virtualized path, so `%APPDATA%` edits may not apply — point `CLAUDE_DESKTOP_CONFIG` at the MSIX path shown.
 - An orphan `%APPDATA%\Claude\claude_desktop_config.json` exists alongside the active MSIX config. Claude Desktop ignores the orphan, so any `mcpServers` entries there are dead. Re-add them against the active config and delete the orphan.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ cdcasasagi locates Claude Desktop's config in this order:
 2. The MSIX virtualized path (`%LOCALAPPDATA%\Packages\<Claude package>\LocalCache\Roaming\Claude\claude_desktop_config.json`), if any MSIX install is detected.
 3. `%APPDATA%\Claude\claude_desktop_config.json` otherwise.
 
-When multiple MSIX packages are detected, cdcasasagi cannot guess which one Claude Desktop is actually using and refuses to proceed. Confirm the path via **Settings > Developer > Edit Config** in Claude Desktop, then set `CLAUDE_DESKTOP_CONFIG` to that path.
+When multiple MSIX package directories are detected, cdcasasagi first tries to disambiguate by checking which candidates actually contain a `claude_desktop_config.json` — a common stale-install scenario (several package folders but only one real config) is handled automatically. cdcasasagi only refuses to proceed when more than one candidate file exists and the active one cannot be guessed. In that case, confirm the path via **Settings > Developer > Edit Config** in Claude Desktop, then set `CLAUDE_DESKTOP_CONFIG` to that path.
 
 Run `cdcasasagi doctor` to check the resolved config path. On Windows it also surfaces two MSIX-specific situations:
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,21 @@ cdcasasagi validate-import -
 
 Once the JSONL validates, feed the same content to `import - --write` to apply it.
 
+### doctor
+
+Check that cdcasasagi can find what it needs to operate:
+
+```
+cdcasasagi doctor
+```
+
+This reports the resolved `mcp-proxy` binary, the active Claude Desktop config path, and whether the config directory is writable. The command exits with a non-zero status when any check fails, so it can be used in scripts.
+
+On Windows, `doctor` also surfaces two MSIX-specific warnings:
+
+- **Claude Desktop MSIX path** — the active config lives under the MSIX virtualized path (`%LOCALAPPDATA%\Packages\...\LocalCache\Roaming\Claude\...`). cdcasasagi reads and writes that path automatically; the warning is informational.
+- **Orphan APPDATA config** — a leftover `%APPDATA%\Claude\claude_desktop_config.json` is present alongside the MSIX-virtualized active config. Claude Desktop reads only the active file, so any `mcpServers` entries in the orphan are ignored. Re-add them against the active config, then delete the orphan.
+
 ### revert
 
 Restore the config from the `.bak` backup created by the last `--write`:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 > While [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) is a great and easy-to-use tool, the scenarios where it is still necessary are likely limited now that official support exists.
 > Additionally, custom connectors work not only with Claude Desktop but also with the web version of Claude, once configured.
 
+> [!NOTE]
+> Windows users: see [Windows notes](#windows-notes) for MSIX-specific config path behavior.
+
 ## Install
 
 ```
@@ -154,3 +157,18 @@ cdcasasagi revert
 ```
 cdcasasagi version
 ```
+
+## Windows notes
+
+cdcasasagi locates Claude Desktop's config in this order:
+
+1. `CLAUDE_DESKTOP_CONFIG` environment variable, if set.
+2. The MSIX virtualized path (`%LOCALAPPDATA%\Packages\<Claude package>\LocalCache\Roaming\Claude\claude_desktop_config.json`), if any MSIX install is detected.
+3. `%APPDATA%\Claude\claude_desktop_config.json` otherwise.
+
+When multiple MSIX packages are detected, cdcasasagi cannot guess which one Claude Desktop is actually using and refuses to proceed. Confirm the path via **Settings > Developer > Edit Config** in Claude Desktop, then set `CLAUDE_DESKTOP_CONFIG` to that path.
+
+Run `cdcasasagi doctor` to check the resolved config path. On Windows it also surfaces two MSIX-specific situations:
+
+- The active config is on the MSIX virtualized path (informational — cdcasasagi handles it automatically).
+- An orphan `%APPDATA%\Claude\claude_desktop_config.json` exists alongside the active MSIX config. Claude Desktop ignores the orphan, so any `mcpServers` entries there are dead. Re-add them against the active config and delete the orphan.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ uv tool install cdcasasagi
 
 ## Usage
 
-The `add` and `import` commands default to **preview mode** (no files are modified). Pass `--write` to apply changes.
+Commands at a glance:
+
+- **Mutating (preview by default, `--write` to apply):** `add`, `import`, `delete`
+- **Read-only:** `list`, `validate-import`, `doctor`
+- **Recovery:** `revert` (restores from the `.bak` left by the last `--write`)
+- **Misc:** `version`
+
+The `add`, `import`, and `delete` commands default to **preview mode** (no files are modified). Pass `--write` to apply changes.  
 For full option details, run `cdcasasagi <command> --help`.
 
 ### add

--- a/README.md
+++ b/README.md
@@ -65,22 +65,6 @@ The written entry looks like this:
 }
 ```
 
-### delete
-
-Remove an entry from the Claude Desktop config by URL:
-
-```
-cdcasasagi delete https://mcp.notion.com/mcp
-```
-
-This shows a unified diff of the proposed removal. Pass `--write` to apply:
-
-```
-cdcasasagi delete https://mcp.notion.com/mcp --write
-```
-
-Only entries added by cdcasasagi (whose `command` is `mcp-proxy`) are removed. Hand-added entries that happen to share a URL are left alone.
-
 ### import
 
 Add multiple entries at once from a JSONL file:
@@ -107,6 +91,22 @@ cdcasasagi import - --write
 # Paste JSONL, then press Enter on a blank line to finish
 # (Ctrl+D / Ctrl+Z also works)
 ```
+
+### delete
+
+Remove an entry from the Claude Desktop config by URL:
+
+```
+cdcasasagi delete https://mcp.notion.com/mcp
+```
+
+This shows a unified diff of the proposed removal. Pass `--write` to apply:
+
+```
+cdcasasagi delete https://mcp.notion.com/mcp --write
+```
+
+Only entries added by cdcasasagi (whose `command` is `mcp-proxy`) are removed. Hand-added entries that happen to share a URL are left alone.
 
 ### list
 


### PR DESCRIPTION
## Summary
- Add a `doctor` section to README (previously undocumented).
- Add a `## Windows notes` section explaining config path resolution order (`CLAUDE_DESKTOP_CONFIG` -> MSIX virtualized path -> `%APPDATA%`) and the multi-MSIX ambiguity behavior.
- Add a "Commands at a glance" summary at the top of `## Usage`, grouping commands by mutating / read-only / recovery / misc.
- Surface the Windows notes section with a top-of-file callout.

## Why
The `doctor` command was shipped but never documented. Recent Windows MSIX work (#52, #54, #55) added user-visible behavior (auto-fallback to the virtualized path, two new MSIX-related warnings) that deserves an explicit Windows section in the README.

## Test plan
- [ ] Render README on GitHub and verify the `#windows-notes` anchor from the top callout jumps correctly.
- [ ] Verify command grouping in the summary matches the section order in the body.