### PR TITLE
feat(doctor): Warn when Python is installed under %APPDATA%

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ cdcasasagi doctor
 
 This reports the resolved `mcp-proxy` binary, the active Claude Desktop config path, and whether the config directory is writable. The command exits with a non-zero status when any check fails, so it can be used in scripts.
 
-On Windows, `doctor` also surfaces two MSIX-specific warnings:
+On Windows, `doctor` also surfaces these warnings:
 
 - **Claude Desktop MSIX path** — the active config is **not** under the MSIX virtualized path, but a Claude MSIX install was detected. Claude Desktop on MSIX reads from the virtualized path (`%LOCALAPPDATA%\Packages\...\LocalCache\Roaming\Claude\...`), so edits to the current path may have no effect. Set `CLAUDE_DESKTOP_CONFIG` to the candidate path shown in the warning.
 - **Orphan APPDATA config** — the active config is on the MSIX virtualized path, and a leftover `%APPDATA%\Claude\claude_desktop_config.json` is also present. Claude Desktop reads only the active file, so any `mcpServers` entries in the orphan are ignored. Re-add them against the active config, then delete the orphan.
+- **Python install path** — the Python interpreter that runs cdcasasagi is under `%APPDATA%\Roaming`, where some Windows security policies block execution. The warning shows a `UV_PYTHON_INSTALL_DIR` workaround that reinstalls Python under `%LOCALAPPDATA%`. See [#57](https://github.com/ftnext/cdcasasagi/issues/57) for background.
 
 ### revert
 
@@ -175,7 +176,8 @@ cdcasasagi locates Claude Desktop's config in this order:
 
 When multiple MSIX package directories are detected, cdcasasagi first tries to disambiguate by checking which candidates actually contain a `claude_desktop_config.json` — a common stale-install scenario (several package folders but only one real config) is handled automatically. cdcasasagi only refuses to proceed when more than one candidate file exists and the active one cannot be guessed. In that case, confirm the path via **Settings > Developer > Edit Config** in Claude Desktop, then set `CLAUDE_DESKTOP_CONFIG` to that path.
 
-Run `cdcasasagi doctor` to check the resolved config path. On Windows it also surfaces two MSIX-specific situations:
+Run `cdcasasagi doctor` to check the resolved config path. On Windows it also surfaces these situations:
 
 - The active config is on `%APPDATA%` while a Claude MSIX install is detected. Claude Desktop on MSIX reads the virtualized path, so `%APPDATA%` edits may not apply — point `CLAUDE_DESKTOP_CONFIG` at the MSIX path shown.
 - An orphan `%APPDATA%\Claude\claude_desktop_config.json` exists alongside the active MSIX config. Claude Desktop ignores the orphan, so any `mcpServers` entries there are dead. Re-add them against the active config and delete the orphan.
+- The Python interpreter that runs cdcasasagi sits under `%APPDATA%\Roaming` (uv's default install location). Some Windows security policies block executing binaries from there, which can prevent cdcasasagi and `mcp-proxy` from running. The warning shows a one-time fix using `UV_PYTHON_INSTALL_DIR` to install Python under `%LOCALAPPDATA%` instead. See [#57](https://github.com/ftnext/cdcasasagi/issues/57) for the upstream context.

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -61,6 +61,9 @@ def doctor() -> None:
             orphan_row = _orphan_appdata_doctor_row(cfg_path)
             if orphan_row is not None:
                 results.append(orphan_row)
+            python_row = _appdata_roaming_python_doctor_row()
+            if python_row is not None:
+                results.append(python_row)
 
     typer.echo(output.doctor_message(results))
     if any(status == "fail" for _, status, _ in results):
@@ -124,6 +127,28 @@ def _orphan_appdata_doctor_row(cfg_path: Path) -> tuple[str, str, str] | None:
         "then delete the orphan file."
     )
     return ("Orphan APPDATA config", "warn", detail)
+
+
+def _appdata_roaming_python_doctor_row() -> tuple[str, str, str] | None:
+    appdata = os.environ.get("APPDATA", "")
+    if not appdata:
+        return None
+    python_path = Path(sys.executable)
+    try:
+        python_path.resolve().relative_to(Path(appdata).resolve())
+    except ValueError:
+        return None
+    detail = (
+        f"Python interpreter is under %APPDATA% ({python_path}).\n"
+        "Some Windows security policies block executing binaries from "
+        "%APPDATA%\\Roaming, which can prevent cdcasasagi and mcp-proxy "
+        "from running.\n"
+        "Workaround: install Python under %LOCALAPPDATA% via uv:\n"
+        '  $env:UV_PYTHON_INSTALL_DIR = "$env:LOCALAPPDATA\\uv\\python"\n'
+        "  uv tool install cdcasasagi --reinstall\n"
+        "See https://github.com/ftnext/cdcasasagi/issues/57 for details."
+    )
+    return ("Python install path", "warn", detail)
 
 
 @app.command(name="list")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -278,6 +278,42 @@ class TestDoctor:
         assert result.exit_code == 0
         assert "Orphan APPDATA config" not in result.output
 
+    def test_appdata_python_warn_when_python_under_appdata(self, monkeypatch, tmp_path):
+        _, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        # Place Python (and mcp-proxy) under %APPDATA%\... to mimic uv's
+        # default install location on Windows.
+        appdata_python_dir = tmp_path / "appdata" / "uv" / "python"
+        appdata_python_dir.mkdir(parents=True)
+        fake_python = appdata_python_dir / "python.exe"
+        fake_python.touch()
+        (appdata_python_dir / "mcp-proxy").touch()
+        monkeypatch.setattr("cdcasasagi.mcp_proxy.sys.executable", str(fake_python))
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "[WARN] Python install path:" in result.output
+        assert "%APPDATA%" in result.output
+        assert "UV_PYTHON_INSTALL_DIR" in result.output
+        assert "issues/57" in result.output
+
+    def test_appdata_python_no_warn_when_python_outside_appdata(
+        self, monkeypatch, tmp_path
+    ):
+        _, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        # Default fixture places Python under tmp_path/bin, outside %APPDATA%.
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "Python install path" not in result.output
+
+    def test_appdata_python_no_warn_when_appdata_unset(self, monkeypatch, tmp_path):
+        _, msix_cfg = self._setup_windows_doctor(monkeypatch, tmp_path)
+        msix_cfg.write_text('{"mcpServers": {}}')
+        monkeypatch.delenv("APPDATA", raising=False)
+        result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "Python install path" not in result.output
+
 
 class TestAmbiguousMsixConfig:
     """`config_path()` raises AmbiguousConfigError when multiple MSIX packages


### PR DESCRIPTION
## Background

On Windows, `uv tool install cdcasasagi` may place the managed Python interpreter under `%APPDATA%\Roaming` (uv's default install location). Some Windows security policies — AppLocker, Windows Defender Application Control, or corporate endpoint policies — block executing binaries from `%APPDATA%\Roaming`, which can prevent cdcasasagi (and the `mcp-proxy` it invokes) from running at all. Even Python stdlib imports can fail.

This is not a bug in cdcasasagi itself; it stems from where uv installs Python on Windows. See #57 and astral-sh/uv#7008 for the upstream context. The workaround is to set `UV_PYTHON_INSTALL_DIR` so uv installs Python under `%LOCALAPPDATA%` instead, and reinstall.

Users who hit this can be silently stuck without realizing the cause, so this PR surfaces the situation in `doctor` and points them at the workaround.

## Summary

- Add a third Windows-specific WARN row to `doctor`: **Python install path**. Fires when `sys.executable` resolves to a path under `%APPDATA%`. The detail shows the resolved path, the PowerShell `UV_PYTHON_INSTALL_DIR` workaround, and a link to #57.
- Update the README's `### doctor` and `## Windows notes` sections to document the new warning, mirroring the existing MSIX bullets.

The check is gated by `_platform.system() == "Windows"` (same pattern as the existing MSIX / orphan-APPDATA rows), so behavior on macOS / Linux is unchanged.

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` — all 261 tests pass, including 3 new `TestDoctor` cases:
  - `test_appdata_python_warn_when_python_under_appdata`
  - `test_appdata_python_no_warn_when_python_outside_appdata`
  - `test_appdata_python_no_warn_when_appdata_unset`
- E2E spec: not added. The behavior is Windows-only and CI runs on macOS, so the existing Gauge harness can't exercise it. Existing macOS / Linux behavior is unaffected.

Closes-relates-to: #57 (the issue stays open as a known-issue marker until uv's default Python install location changes upstream).