### PR TITLE
feat(delete): Identify the target by name instead of URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,19 +94,19 @@ cdcasasagi import - --write
 
 ### delete
 
-Remove an entry from the Claude Desktop config by URL:
+Remove an entry from the Claude Desktop config by name:
 
 ```
-cdcasasagi delete https://mcp.notion.com/mcp
+cdcasasagi delete notion
 ```
 
 This shows a unified diff of the proposed removal. Pass `--write` to apply:
 
 ```
-cdcasasagi delete https://mcp.notion.com/mcp --write
+cdcasasagi delete notion --write
 ```
 
-Only entries added by cdcasasagi (whose `command` is `mcp-proxy`) are removed. Hand-added entries that happen to share a URL are left alone.
+Names match the left column of `cdcasasagi list` output. Only entries managed by cdcasasagi (whose `command` is `mcp-proxy`) can be deleted; if the named entry was hand-added, `delete` refuses with an error so you can edit the config manually.
 
 ### list
 

--- a/e2e/specs/delete.spec
+++ b/e2e/specs/delete.spec
@@ -1,10 +1,10 @@
 # cdcasasagi delete
 
 E2E for `cdcasasagi delete`, which removes a cdcasasagi-managed MCP server
-entry by URL. These scenarios seed `claude_desktop_config.json` directly
+entry by name. These scenarios seed `claude_desktop_config.json` directly
 (no `add --write`) so they can cover hand-added entries whose `command` is
 not `mcp-proxy` -- a shape `add` would never produce. That lets us verify
-`delete` leaves such entries alone.
+`delete` refuses to touch them and returns a clear error.
 
 The revert round-trip runs last on purpose: it unlinks the `.bak` the other
 `--write` scenarios leave behind, so the next spec starts without a leftover
@@ -16,9 +16,9 @@ backup (mirrors `add_write.spec`).
    |name  |command  |args                                                 |
    |------|---------|-----------------------------------------------------|
    |notion|mcp-proxy|--transport,streamablehttp,https://mcp.notion.com/mcp|
-* Run cdcasasagi "delete https://mcp.notion.com/mcp"
+* Run cdcasasagi "delete notion"
 * The last command succeeds
-* The delete preview announces removal of "https://mcp.notion.com/mcp"
+* The delete preview announces removal of "notion"
 * The config file is unchanged
 
 ## --write removes only the matching managed entry and creates a backup
@@ -29,53 +29,37 @@ backup (mirrors `add_write.spec`).
    |notion    |mcp-proxy|--transport,streamablehttp,https://mcp.notion.com/mcp       |
    |developers|mcp-proxy|--transport,streamablehttp,https://developers.openai.com/mcp|
    |legacy    |node     |/path/to/hand-added-server.js                               |
-* Run cdcasasagi "delete https://mcp.notion.com/mcp --write"
+* Run cdcasasagi "delete notion --write"
 * The last command succeeds
 * "developers,legacy" entries are written to the config file
 * The backup file is created
 * "notion,developers,legacy" entries are written to the backup file
 
-## A hand-added entry that shares the URL is left alone
+## Refuses to delete a hand-added entry
 
-The hand-added entry deliberately mirrors the mcp-proxy args shape (same
-`--transport`, same URL) so only the `command` basename check distinguishes
-it from a managed entry. A regression that dropped that check would cause
-the hand-added entry to be removed, and this scenario would catch it.
-
-* Claude Desktop's config has the following mcpServers entries
-   |name       |command  |args                                                 |
-   |-----------|---------|-----------------------------------------------------|
-   |notion     |mcp-proxy|--transport,streamablehttp,https://mcp.notion.com/mcp|
-   |notion-hand|node     |--transport,streamablehttp,https://mcp.notion.com/mcp|
-* Run cdcasasagi "delete https://mcp.notion.com/mcp --write"
-* The last command succeeds
-* "notion-hand" entry is written to the config file
-
-## delete fails when only a hand-added entry matches the URL
-
-Same principle as the previous scenario: the hand-added entry's args exactly
-match what `delete` looks for, so only the `command` basename check prevents
-the match. Without a managed entry, `delete` must fail with
-`EntryNotFoundError` rather than fall through to the hand-added one.
+The named entry's `command` is `node`, not `mcp-proxy`, so `delete` must
+refuse with a specific "not managed by cdcasasagi" error rather than remove
+it. A regression that dropped the command-basename check would silently
+delete the hand-added entry, and this scenario would catch it.
 
 * Claude Desktop's config has the following mcpServers entries
    |name       |command|args                                                 |
    |-----------|-------|-----------------------------------------------------|
    |notion-hand|node   |--transport,streamablehttp,https://mcp.notion.com/mcp|
-* Run cdcasasagi "delete https://mcp.notion.com/mcp"
+* Run cdcasasagi "delete notion-hand --write"
 * The last command fails
-* stderr contains "No cdcasasagi-managed entry found"
+* stderr contains "not managed by cdcasasagi"
 * The config file is unchanged
 
-## delete fails when the URL is not present
+## delete fails when the name is not present
 
 * Claude Desktop's config has the following mcpServers entries
    |name  |command  |args                                                 |
    |------|---------|-----------------------------------------------------|
    |notion|mcp-proxy|--transport,streamablehttp,https://mcp.notion.com/mcp|
-* Run cdcasasagi "delete https://other.example.com/mcp"
+* Run cdcasasagi "delete missing"
 * The last command fails
-* stderr contains "No cdcasasagi-managed entry found"
+* stderr contains "No entry found with name: missing"
 * The config file is unchanged
 
 ## revert round-trips a delete --write
@@ -86,7 +70,7 @@ the match. Without a managed entry, `delete` must fail with
    |notion    |mcp-proxy|--transport,streamablehttp,https://mcp.notion.com/mcp       |
    |developers|mcp-proxy|--transport,streamablehttp,https://developers.openai.com/mcp|
    |legacy    |node     |/path/to/hand-added-server.js                               |
-* Run cdcasasagi "delete https://mcp.notion.com/mcp --write"
+* Run cdcasasagi "delete notion --write"
 * "developers,legacy" entries are written to the config file
 * Run cdcasasagi "revert"
 * "notion,developers,legacy" entries are written to the config file

--- a/e2e/step_impl/steps_delete.py
+++ b/e2e/step_impl/steps_delete.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 from getgauge.python import data_store, step
 
 
-@step("The delete preview announces removal of <url>")
-def assert_delete_preview_announces(url):
-    """Assert stdout is a delete preview for *url* (not a write output).
+@step("The delete preview announces removal of <name>")
+def assert_delete_preview_announces(name):
+    """Assert stdout is a delete preview for *name* (not a write output).
 
-    Distinguishes the preview from the write-mode message: both mention the
-    URL and the removed name, but only the preview ends with the re-run hint.
+    Distinguishes the preview from the write-mode message: both quote the
+    name and URL, but only the preview ends with the re-run hint.
     """
     result = data_store.scenario["last_result"]
     stdout = result.stdout
-    for expected in ("Will remove", url, "Re-run with --write to apply"):
+    for expected in ("Will remove", f'"{name}"', "Re-run with --write to apply"):
         assert expected in stdout, (
             f"delete preview is missing {expected!r}\nstdout:\n{stdout}"
         )

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -231,7 +231,7 @@ def add(
 
 @app.command()
 def delete(
-    url: str = typer.Argument(..., help="URL of the mcpServers entry to remove"),
+    name: str = typer.Argument(..., help="Name of the mcpServers entry to remove"),
     write: bool = typer.Option(False, help="Actually write to the file"),
 ) -> None:
     try:
@@ -242,17 +242,22 @@ def delete(
         raise typer.Exit(code=1)
 
     try:
-        updated, removed = desktop_config.remove_entries_by_url(current_config, url)
-    except desktop_config.EntryNotFoundError as e:
+        updated, removed_url = desktop_config.remove_entry_by_name(current_config, name)
+    except (
+        desktop_config.EntryNotFoundError,
+        desktop_config.EntryNotManagedError,
+    ) as e:
         typer.echo(str(e), err=True)
         raise typer.Exit(code=1)
 
     if not write:
         diff_text = output.format_diff(current_config, updated)
-        typer.echo(output.delete_preview_message(url, removed, cfg_path, diff_text))
+        typer.echo(
+            output.delete_preview_message(name, removed_url, cfg_path, diff_text)
+        )
     else:
         desktop_config.write_config(cfg_path, updated)
-        typer.echo(output.delete_write_message(url, removed, cfg_path))
+        typer.echo(output.delete_write_message(name, removed_url, cfg_path))
 
 
 @app.command()

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -33,6 +33,10 @@ class DuplicateUrlError(Exception):
     pass
 
 
+class EntryNotManagedError(Exception):
+    pass
+
+
 class BackupError(Exception):
     pass
 
@@ -242,35 +246,39 @@ def merge_entry(
     return config
 
 
-def remove_entries_by_url(
-    config: dict[str, Any], url: str
-) -> tuple[dict[str, Any], list[str]]:
-    """Remove every cdcasasagi-managed entry whose URL matches.
+def remove_entry_by_name(
+    config: dict[str, Any], name: str
+) -> tuple[dict[str, Any], str]:
+    """Remove the cdcasasagi-managed entry under *name*.
 
     An entry is considered managed when ``command`` basename is ``mcp-proxy``
     (or ``mcp-proxy.exe``) and ``args`` starts with ``--transport`` followed
     by a transport value and the URL -- the same shape written by ``add``
-    and required by ``list_mcp_proxy_entries``. Hand-edited entries that
-    happen to end in *url* are left alone. Raises :class:`EntryNotFoundError`
-    when nothing matches. Returns ``(updated_config, removed_names)``.
+    and required by ``list_mcp_proxy_entries``. Raises
+    :class:`EntryNotFoundError` when *name* is absent and
+    :class:`EntryNotManagedError` when the entry exists but is hand-added.
+    Returns ``(updated_config, removed_url)``.
     """
     config = json.loads(json.dumps(config))  # deep copy
     servers = config.setdefault("mcpServers", {})
-    names: list[str] = []
-    for name, entry in servers.items():
-        cmd = entry.get("command", "")
-        if Path(cmd).name not in {"mcp-proxy", "mcp-proxy.exe"}:
-            continue
-        args = entry.get("args", [])
-        if len(args) < 3 or args[0] != "--transport":
-            continue
-        if args[-1] == url:
-            names.append(name)
-    if not names:
-        raise EntryNotFoundError(f"No cdcasasagi-managed entry found for URL: {url}")
-    for name in names:
-        del servers[name]
-    return config, names
+    if name not in servers:
+        raise EntryNotFoundError(f"No entry found with name: {name}")
+    entry = servers[name]
+    cmd = entry.get("command", "")
+    if Path(cmd).name not in {"mcp-proxy", "mcp-proxy.exe"}:
+        raise EntryNotManagedError(
+            f'Entry "{name}" is not managed by cdcasasagi '
+            "(command is not mcp-proxy). Refusing to delete."
+        )
+    args = entry.get("args", [])
+    if len(args) < 3 or args[0] != "--transport":
+        raise EntryNotManagedError(
+            f'Entry "{name}" has an unrecognized args shape and is not '
+            "managed by cdcasasagi. Refusing to delete."
+        )
+    url = args[-1]
+    del servers[name]
+    return config, url
 
 
 def plan_import(

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -78,28 +78,26 @@ def revert_message(
 
 
 def delete_preview_message(
-    url: str, removed_names: list[str], config_path: Path, diff_text: str
+    name: str, url: str, config_path: Path, diff_text: str
 ) -> str:
-    names = _format_replaces(removed_names)
     lines = [
         f"Target: {config_path}",
         "",
         diff_text.rstrip(),
         "",
-        f"Will remove {names} ({url}).",
+        f'Will remove "{name}" ({url}).',
         "This is a preview. Re-run with --write to apply.",
     ]
     return "\n".join(lines)
 
 
-def delete_write_message(url: str, removed_names: list[str], config_path: Path) -> str:
+def delete_write_message(name: str, url: str, config_path: Path) -> str:
     backup = config_path.with_suffix(config_path.suffix + ".bak")
-    names = _format_replaces(removed_names)
     lines = [
         f"Backup: {backup}",
         f"Wrote:  {config_path}",
         "",
-        f"Removed {names} ({url}). Restart Claude Desktop to take effect.",
+        f'Removed "{name}" ({url}). Restart Claude Desktop to take effect.',
     ]
     return "\n".join(lines)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -764,7 +764,7 @@ class TestDelete:
             json.dumps({"mcpServers": {"notion": self._managed(fake_proxy, url)}})
         )
         before = config_file.read_text()
-        result = runner.invoke(app, ["delete", url])
+        result = runner.invoke(app, ["delete", "notion"])
         assert result.exit_code == 0
         assert f"Target: {config_file}" in result.output
         assert "--- current" in result.output
@@ -789,7 +789,7 @@ class TestDelete:
                 }
             )
         )
-        result = runner.invoke(app, ["delete", notion_url, "--write"])
+        result = runner.invoke(app, ["delete", "notion", "--write"])
         assert result.exit_code == 0
         data = json.loads(config_file.read_text())
         assert "notion" not in data["mcpServers"]
@@ -799,7 +799,7 @@ class TestDelete:
         assert f'Removed "notion" ({notion_url}).' in result.output
         assert "Restart Claude Desktop" in result.output
 
-    def test_url_not_found(self, config_env):
+    def test_name_not_found(self, config_env):
         config_file, fake_proxy = config_env
         config_file.write_text(
             json.dumps(
@@ -813,35 +813,34 @@ class TestDelete:
             )
         )
         before = config_file.read_text()
-        result = runner.invoke(app, ["delete", "https://missing.example.com/mcp"])
+        result = runner.invoke(app, ["delete", "missing"])
         assert result.exit_code == 1
-        assert "No cdcasasagi-managed entry found" in result.output
-        assert "https://missing.example.com/mcp" in result.output
+        assert "No entry found with name: missing" in result.output
         assert config_file.read_text() == before
 
     def test_no_config_file(self, config_env):
         config_file, _ = config_env
         assert not config_file.exists()
-        result = runner.invoke(app, ["delete", "https://mcp.notion.com/mcp"])
+        result = runner.invoke(app, ["delete", "anything"])
         assert result.exit_code == 1
-        assert "No cdcasasagi-managed entry found" in result.output
+        assert "No entry found with name: anything" in result.output
 
     def test_corrupt_config(self, config_env):
         config_file, _ = config_env
         config_file.write_text("not json at all")
-        result = runner.invoke(app, ["delete", "https://mcp.notion.com/mcp"])
+        result = runner.invoke(app, ["delete", "notion"])
         assert result.exit_code == 1
         assert "Failed to parse JSON config file" in result.output
 
-    def test_ignores_non_managed_entry_with_matching_url(self, config_env):
+    def test_refuses_hand_added_entry(self, config_env):
         config_file, _ = config_env
         url = "https://mcp.notion.com/mcp"
         config_file.write_text(
             json.dumps(
                 {
                     "mcpServers": {
-                        "custom": {
-                            "command": "/usr/bin/some-other-tool",
+                        "notion-hand": {
+                            "command": "/usr/bin/node",
                             "args": ["--transport", "streamablehttp", url],
                         }
                     }
@@ -849,9 +848,26 @@ class TestDelete:
             )
         )
         before = config_file.read_text()
-        result = runner.invoke(app, ["delete", url, "--write"])
+        result = runner.invoke(app, ["delete", "notion-hand", "--write"])
         assert result.exit_code == 1
-        assert "No cdcasasagi-managed entry found" in result.output
+        assert "not managed by cdcasasagi" in result.output
+        assert config_file.read_text() == before
+
+    def test_refuses_malformed_managed_shape(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "weird": {"command": "mcp-proxy", "args": ["--other"]},
+                    }
+                }
+            )
+        )
+        before = config_file.read_text()
+        result = runner.invoke(app, ["delete", "weird"])
+        assert result.exit_code == 1
+        assert "not managed by cdcasasagi" in result.output
         assert config_file.read_text() == before
 
     def test_delete_then_revert_restores(self, config_env):
@@ -865,7 +881,7 @@ class TestDelete:
             }
         }
         config_file.write_text(json.dumps(original))
-        result = runner.invoke(app, ["delete", notion_url, "--write"])
+        result = runner.invoke(app, ["delete", "notion", "--write"])
         assert result.exit_code == 0
         result = runner.invoke(app, ["revert"])
         assert result.exit_code == 0

--- a/tests/test_desktop_config.py
+++ b/tests/test_desktop_config.py
@@ -10,6 +10,7 @@ from cdcasasagi.desktop_config import (
     ConfigError,
     EntryExistsError,
     EntryNotFoundError,
+    EntryNotManagedError,
     apply_import,
     backup_path,
     build_entry,
@@ -20,7 +21,7 @@ from cdcasasagi.desktop_config import (
     load_config,
     merge_entry,
     plan_import,
-    remove_entries_by_url,
+    remove_entry_by_name,
     revert_config,
     write_config,
 )
@@ -331,7 +332,7 @@ class TestMergeEntry:
         assert result["mcpServers"]["a"] == new
 
 
-class TestRemoveEntriesByUrl:
+class TestRemoveEntryByName:
     def _managed(self, url, command="mcp-proxy"):
         return {"command": command, "args": ["--transport", "streamablehttp", url]}
 
@@ -343,65 +344,80 @@ class TestRemoveEntriesByUrl:
                 "linear": self._managed("https://mcp.linear.app/mcp"),
             }
         }
-        result, removed = remove_entries_by_url(config, url)
-        assert removed == ["notion"]
+        result, removed_url = remove_entry_by_name(config, "notion")
+        assert removed_url == url
         assert "notion" not in result["mcpServers"]
         assert "linear" in result["mcpServers"]
 
+    def test_returns_url_extracted_from_args(self):
+        url = "https://developers.openai.com/mcp"
+        config = {"mcpServers": {"developers": self._managed(url)}}
+        _, removed_url = remove_entry_by_name(config, "developers")
+        assert removed_url == url
+
     def test_preserves_unrelated_top_level_keys(self):
-        url = "https://mcp.notion.com/mcp"
-        config = {"mcpServers": {"notion": self._managed(url)}, "other": "keep"}
-        result, _ = remove_entries_by_url(config, url)
+        config = {
+            "mcpServers": {"notion": self._managed("https://mcp.notion.com/mcp")},
+            "other": "keep",
+        }
+        result, _ = remove_entry_by_name(config, "notion")
         assert result["other"] == "keep"
 
-    def test_missing_url_raises(self):
+    def test_name_not_found_raises(self):
         config = {"mcpServers": {"notion": self._managed("https://mcp.notion.com/mcp")}}
-        with pytest.raises(EntryNotFoundError):
-            remove_entries_by_url(config, "https://other.example.com/mcp")
+        with pytest.raises(EntryNotFoundError) as excinfo:
+            remove_entry_by_name(config, "missing")
+        assert "No entry found with name: missing" in str(excinfo.value)
 
-    def test_missing_mcpservers_raises(self):
+    def test_missing_mcpservers_raises_not_found(self):
         config = {"other": "value"}
         with pytest.raises(EntryNotFoundError):
-            remove_entries_by_url(config, "https://mcp.notion.com/mcp")
-
-    def test_empty_mcpservers_raises(self):
-        config = {"mcpServers": {}}
-        with pytest.raises(EntryNotFoundError):
-            remove_entries_by_url(config, "https://mcp.notion.com/mcp")
+            remove_entry_by_name(config, "notion")
 
     def test_does_not_mutate_original(self):
-        url = "https://mcp.notion.com/mcp"
-        config = {"mcpServers": {"notion": self._managed(url)}}
-        remove_entries_by_url(config, url)
+        config = {"mcpServers": {"notion": self._managed("https://mcp.notion.com/mcp")}}
+        remove_entry_by_name(config, "notion")
         assert "notion" in config["mcpServers"]
 
-    def test_ignores_non_mcp_proxy_command(self):
+    def test_hand_added_non_mcp_proxy_command_raises_not_managed(self):
         url = "https://mcp.notion.com/mcp"
         config = {
             "mcpServers": {
-                "impostor": {
-                    "command": "/usr/bin/some-other-tool",
+                "notion-hand": {
+                    "command": "/usr/bin/node",
                     "args": ["--transport", "streamablehttp", url],
                 }
             }
         }
-        with pytest.raises(EntryNotFoundError):
-            remove_entries_by_url(config, url)
-        assert "impostor" in config["mcpServers"]
+        with pytest.raises(EntryNotManagedError) as excinfo:
+            remove_entry_by_name(config, "notion-hand")
+        assert "not managed by cdcasasagi" in str(excinfo.value)
+        assert "notion-hand" in config["mcpServers"]
 
-    def test_ignores_malformed_args_shape(self):
+    def test_hand_added_malformed_args_raises_not_managed(self):
         url = "https://mcp.notion.com/mcp"
         config = {
             "mcpServers": {
-                "short": {"command": "mcp-proxy", "args": [url]},
-                "wrong_flag": {
+                "weird": {
                     "command": "mcp-proxy",
                     "args": ["--other", "x", url],
-                },
+                }
             }
         }
-        with pytest.raises(EntryNotFoundError):
-            remove_entries_by_url(config, url)
+        with pytest.raises(EntryNotManagedError):
+            remove_entry_by_name(config, "weird")
+
+    def test_hand_added_short_args_raises_not_managed(self):
+        config = {
+            "mcpServers": {
+                "short": {
+                    "command": "mcp-proxy",
+                    "args": ["https://mcp.notion.com/mcp"],
+                }
+            }
+        }
+        with pytest.raises(EntryNotManagedError):
+            remove_entry_by_name(config, "short")
 
     def test_mcp_proxy_exe_command_matches(self):
         url = "https://mcp.notion.com/mcp"
@@ -413,25 +429,23 @@ class TestRemoveEntriesByUrl:
                 }
             }
         }
-        result, removed = remove_entries_by_url(config, url)
-        assert removed == ["notion"]
+        result, removed_url = remove_entry_by_name(config, "notion")
+        assert removed_url == url
         assert "notion" not in result["mcpServers"]
 
-    def test_removes_all_duplicate_url_managed_entries(self):
-        """Hand-edited config with two managed entries sharing a URL: both go."""
+    def test_not_managed_does_not_mutate_original(self):
         url = "https://mcp.notion.com/mcp"
         config = {
             "mcpServers": {
-                "notion": self._managed(url),
-                "notion-2": self._managed(url),
-                "other": self._managed("https://other.example.com/mcp"),
+                "notion-hand": {
+                    "command": "node",
+                    "args": ["--transport", "streamablehttp", url],
+                }
             }
         }
-        result, removed = remove_entries_by_url(config, url)
-        assert sorted(removed) == ["notion", "notion-2"]
-        assert "notion" not in result["mcpServers"]
-        assert "notion-2" not in result["mcpServers"]
-        assert "other" in result["mcpServers"]
+        with pytest.raises(EntryNotManagedError):
+            remove_entry_by_name(config, "notion-hand")
+        assert config["mcpServers"]["notion-hand"]["command"] == "node"
 
 
 class TestWriteConfig:


### PR DESCRIPTION
## Summary

- `cdcasasagi delete <name>` replaces `cdcasasagi delete <url>`. `add` / `import` already enforce URL uniqueness, so URL-scoped removal never had multiple aliases to chew on; meanwhile `list` outputs `name : url`, making name the natural follow-up after listing.
- Hand-added entries (whose `command` is not `mcp-proxy`/`mcp-proxy.exe`) are now refused with a dedicated `EntryNotManagedError` so the rejection reason is explicit, instead of being silently invisible to URL search.
- `desktop_config.remove_entries_by_url` is replaced by `remove_entry_by_name`, returning `(updated_config, removed_url)` since name is a unique dict key (single match by construction).
- Output, unit tests, the `delete` E2E spec, and the README are updated to match.

This is a deliberate breaking CLI change — `delete` no longer accepts a URL.

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check --fix src/ tests/`
- [x] `uv run --no-sync pytest` — 263 passed
- [x] `cd e2e && CLAUDE_DESKTOP_CONFIG=/tmp/test-claude-config.json uv run gauge run specs` — 8 specs / 27 scenarios passed
- [x] `grep -rn "remove_entries_by_url\|No cdcasasagi-managed entry" src tests e2e` returns no hits

https://claude.ai/code/session_014jT1urLdWYPEZH1r1b7zWj

---
_Generated by [Claude Code](https://claude.ai/code/session_014jT1urLdWYPEZH1r1b7zWj)_