### PR TITLE
feat(eject): Add command to print managed entries as JSONL and clear them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ When adding a new command, decide which layer it serves and whether it participa
 
 ## Design Rules
 
-- Always default to preview (non-destructive). Require `--write` to mutate files.
+- Always default to preview (non-destructive). Require `--write` to mutate files. Recovery commands (`revert`, `eject`) are deliberately exempt: they are escape hatches whose value is acting in a single step, and `eject` always leaves a `.bak` that `revert` can roll back.
 - Import is all-or-nothing: any validation/planning/conflict error → nothing is written.
 - Never modify top-level keys other than `mcpServers`.
 - Assume config structure is valid (Claude Desktop is using it). Only handle `mcpServers` key being absent (create as `{}`). Do not add handling for non-object JSON or non-dict `mcpServers` (see reverts `0f936eb`, `9a7cb75`).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Commands at a glance:
 
 - **Mutating (preview by default, `--write` to apply):** `add`, `import`, `delete`
 - **Read-only:** `list`, `validate-import`, `doctor`
-- **Recovery:** `revert` (restores from the `.bak` left by the last `--write`)
+- **Recovery:** `revert` (restores from the `.bak` left by the last `--write`), `eject` (prints managed entries as JSONL and clears them, for re-import after edits)
 - **Misc:** `version`
 
 The `add`, `import`, and `delete` commands default to **preview mode** (no files are modified). Pass `--write` to apply changes.  
@@ -159,6 +159,18 @@ Restore the config from the `.bak` backup created by the last `--write`:
 ```
 cdcasasagi revert
 ```
+
+### eject
+
+Print all cdcasasagi-managed entries as JSONL on stdout, then remove them from the config. Useful when you want to re-import a slightly modified set of entries: redirect the output to a file, edit it, and re-import.
+
+```
+cdcasasagi eject > backup.jsonl
+# edit backup.jsonl
+cdcasasagi import backup.jsonl --write
+```
+
+The status summary is printed to stderr so stdout stays a clean JSONL stream that can be redirected or piped. Hand-added entries (whose `command` is not `mcp-proxy`) are preserved. Run `cdcasasagi revert` to undo an `eject` if needed.
 
 ### version
 

--- a/docs/author-workflow.md
+++ b/docs/author-workflow.md
@@ -55,6 +55,18 @@ The only keyboard action is pasting the JSONL and terminating stdin.
 
 `validate-import` is the *author's* composition tool. Before sharing the JSONL, the author can paste it into `cdcasasagi validate-import -` locally to confirm schema / URL validity without touching their own config. `validate-import` deliberately has no `--write` option and does not write any files — it is strictly a read-only validator, keeping "validate" and "mutate the config" as separate concerns.
 
+### Re-importing a modified JSONL
+
+If the author needs to tweak a few of the entries already imported, the painless path is `cdcasasagi eject`. It prints the cdcasasagi-managed entries as JSONL on stdout (in the exact shape `import` accepts) and clears them from the config in one step. The author redirects the output to a file, edits it, and ships the usual `cdcasasagi import - --write` paste to the non-developer — no `--force`, no conflict resolution, and no need to remember the original JSONL.
+
+```
+cdcasasagi eject > current.jsonl   # round-trip via JSONL
+# edit current.jsonl
+cdcasasagi import current.jsonl --write   # re-import the modified set
+```
+
+If the eject was a mistake, `cdcasasagi revert` restores the previous state from the `.bak` it left behind.
+
 ## Recovery
 
 If a `--write` command produces an unexpected result, the non-developer runs:

--- a/e2e/specs/eject.spec
+++ b/e2e/specs/eject.spec
@@ -1,0 +1,64 @@
+# cdcasasagi eject
+
+E2E for `cdcasasagi eject`: it prints cdcasasagi-managed entries as JSONL on
+stdout, removes them from the config (preserving hand-added entries), and
+its stdout can be piped straight back into `import` to restore them. These
+checks run through real subprocesses so the stdout/stderr split and `.bak`
+side effect are exercised end-to-end.
+
+The revert round-trip runs last on purpose: it unlinks the `.bak` the other
+`--write` scenarios leave behind, so the next spec starts without a leftover
+backup (mirrors `delete.spec`).
+
+## eject prints JSONL on stdout and clears managed entries
+
+* Claude Desktop's config has the following mcpServers entries
+   |name      |command  |args                                                        |
+   |----------|---------|------------------------------------------------------------|
+   |notion    |mcp-proxy|--transport,streamablehttp,https://mcp.notion.com/mcp       |
+   |developers|mcp-proxy|--transport,streamablehttp,https://developers.openai.com/mcp|
+   |legacy    |node     |/path/to/hand-added-server.js                               |
+* Run cdcasasagi "eject"
+* The last command succeeds
+* stdout has "2" JSONL lines
+* stdout contains "https://mcp.notion.com/mcp"
+* stdout contains "https://developers.openai.com/mcp"
+* stderr contains "Ejected 2 entries"
+* "legacy" entry is written to the config file
+* "notion,developers,legacy" entries are written to the backup file
+
+## eject is a no-op when no managed entries exist
+
+* Claude Desktop's config has the following mcpServers entries
+   |name  |command|args                          |
+   |------|-------|------------------------------|
+   |legacy|node   |/path/to/hand-added-server.js |
+* Run cdcasasagi "eject"
+* The last command succeeds
+* stderr contains "No cdcasasagi-managed entries to eject."
+* The config file is unchanged
+
+## ejected JSONL piped back into import restores the entries
+
+* Claude Desktop's config has the following mcpServers entries
+   |name      |command  |args                                                        |
+   |----------|---------|------------------------------------------------------------|
+   |notion    |mcp-proxy|--transport,streamablehttp,https://mcp.notion.com/mcp       |
+   |developers|mcp-proxy|--transport,streamablehttp,https://developers.openai.com/mcp|
+* Run cdcasasagi "eject"
+* The last command succeeds
+* Pipe the previous stdout to cdcasasagi "import - --write"
+* "notion,developers" entries are written to the config file
+
+## revert round-trips an eject
+
+* Claude Desktop's config has the following mcpServers entries
+   |name  |command  |args                                                 |
+   |------|---------|-----------------------------------------------------|
+   |notion|mcp-proxy|--transport,streamablehttp,https://mcp.notion.com/mcp|
+   |legacy|node     |/path/to/hand-added-server.js                        |
+* Run cdcasasagi "eject"
+* "legacy" entry is written to the config file
+* Run cdcasasagi "revert"
+* "notion,legacy" entries are written to the config file
+* The URL of "notion" in the config file is "https://mcp.notion.com/mcp"

--- a/e2e/step_impl/steps_eject.py
+++ b/e2e/step_impl/steps_eject.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+
+from getgauge.python import data_store, step
+
+
+@step("stdout has <count> JSONL lines")
+def assert_stdout_jsonl_line_count(count):
+    result = data_store.scenario["last_result"]
+    expected = int(count)
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) == expected, (
+        f"expected {expected} JSONL lines on stdout, got {len(lines)}\n"
+        f"stdout:\n{result.stdout}"
+    )
+
+
+@step("Pipe the previous stdout to cdcasasagi <args>")
+def pipe_previous_stdout_to_cdcasasagi(args):
+    previous = data_store.scenario["last_result"]
+    cmd = [sys.executable, "-m", "cdcasasagi"] + shlex.split(args)
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, input=previous.stdout
+    )
+    data_store.scenario["last_result"] = result

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -295,12 +295,15 @@ def eject() -> None:
         typer.echo(output.eject_noop_message(cfg_path), err=True)
         return
 
-    typer.echo(_format_eject_jsonl(managed))
-
+    # Build the JSONL up-front but emit it only after write_config succeeds,
+    # so a failing write never leaves a "successful" JSONL on stdout that a
+    # script could pipe back into `import` against the still-present entries.
+    jsonl_text = _format_eject_jsonl(managed)
     cleaned = desktop_config.remove_managed_entries(
         current_config, [name for name, _, _ in managed]
     )
     desktop_config.write_config(cfg_path, cleaned)
+    typer.echo(jsonl_text)
     typer.echo(output.eject_message(cfg_path, len(managed)), err=True)
 
 

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -260,6 +260,50 @@ def delete(
         typer.echo(output.delete_write_message(name, removed_url, cfg_path))
 
 
+def _format_eject_jsonl(entries: list[tuple[str, str, str]]) -> str:
+    """Render *(name, url, transport)* entries as JSONL, omitting default
+    values so the output is minimal but round-trippable through ``import``.
+    """
+    lines: list[str] = []
+    for name, url, transport in entries:
+        try:
+            name_is_derived = server_name.derive_server_name(url) == name
+        except server_name.NameDerivationError:
+            name_is_derived = False
+
+        payload: dict[str, str] = {"url": url}
+        if not name_is_derived:
+            payload["name"] = name
+        if transport != "streamablehttp":
+            payload["transport"] = transport
+        lines.append(json.dumps(payload, ensure_ascii=False))
+    return "\n".join(lines)
+
+
+@app.command()
+def eject() -> None:
+    """Print managed entries as JSONL to stdout, then remove them from config."""
+    try:
+        cfg_path = desktop_config.config_path()
+        current_config = desktop_config.load_config(cfg_path)
+    except desktop_config.ConfigError as e:
+        typer.echo(str(e), err=True)
+        raise typer.Exit(code=1)
+
+    managed = desktop_config.collect_managed_entries(current_config)
+    if not managed:
+        typer.echo(output.eject_noop_message(cfg_path), err=True)
+        return
+
+    typer.echo(_format_eject_jsonl(managed))
+
+    cleaned = desktop_config.remove_managed_entries(
+        current_config, [name for name, _, _ in managed]
+    )
+    desktop_config.write_config(cfg_path, cleaned)
+    typer.echo(output.eject_message(cfg_path, len(managed)), err=True)
+
+
 @app.command()
 def revert() -> None:
     try:

--- a/src/cdcasasagi/cli.py
+++ b/src/cdcasasagi/cli.py
@@ -276,7 +276,7 @@ def _format_eject_jsonl(entries: list[tuple[str, str, str]]) -> str:
             payload["name"] = name
         if transport != "streamablehttp":
             payload["transport"] = transport
-        lines.append(json.dumps(payload, ensure_ascii=False))
+        lines.append(json.dumps(payload))
     return "\n".join(lines)
 
 

--- a/src/cdcasasagi/desktop_config.py
+++ b/src/cdcasasagi/desktop_config.py
@@ -184,6 +184,39 @@ def list_mcp_proxy_entries(config: dict[str, Any]) -> list[tuple[str, str]]:
     return result
 
 
+def collect_managed_entries(
+    config: dict[str, Any],
+) -> list[tuple[str, str, str]]:
+    """Return ``(name, url, transport)`` for managed entries, sorted by name.
+
+    Uses the same shape check as :func:`list_mcp_proxy_entries` and adds the
+    transport from ``args[1]``.
+    """
+    result: list[tuple[str, str, str]] = []
+    for name, entry in config.get("mcpServers", {}).items():
+        cmd = entry.get("command", "")
+        if Path(cmd).name not in {"mcp-proxy", "mcp-proxy.exe"}:
+            continue
+        args = entry.get("args", [])
+        if len(args) < 3 or args[0] != "--transport":
+            continue
+        result.append((name, args[-1], args[1]))
+    result.sort(key=lambda x: x[0])
+    return result
+
+
+def remove_managed_entries(config: dict[str, Any], names: list[str]) -> dict[str, Any]:
+    """Return a deep copy of *config* with the given names dropped from
+    ``mcpServers``. Caller is expected to have validated that the names refer
+    to managed entries (e.g. via :func:`collect_managed_entries`).
+    """
+    config = json.loads(json.dumps(config))
+    servers = config.setdefault("mcpServers", {})
+    for name in names:
+        servers.pop(name, None)
+    return config
+
+
 def build_entry(mcp_proxy_path: Path, transport: str, url: str) -> dict[str, Any]:
     return {
         "command": str(mcp_proxy_path),

--- a/src/cdcasasagi/output.py
+++ b/src/cdcasasagi/output.py
@@ -102,6 +102,24 @@ def delete_write_message(name: str, url: str, config_path: Path) -> str:
     return "\n".join(lines)
 
 
+def eject_message(cfg_path: Path, count: int) -> str:
+    backup = cfg_path.with_suffix(cfg_path.suffix + ".bak")
+    entry_word = "entry" if count == 1 else "entries"
+    return "\n".join(
+        [
+            f"Backup: {backup}",
+            f"Wrote:  {cfg_path}",
+            "",
+            f"Ejected {count} {entry_word}. Restart Claude Desktop to take effect.",
+            "Run `cdcasasagi revert` to undo.",
+        ]
+    )
+
+
+def eject_noop_message(cfg_path: Path) -> str:
+    return f"No cdcasasagi-managed entries to eject.\nTarget: {cfg_path}"
+
+
 def write_message(
     name: str,
     name_was_derived: bool,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1641,3 +1641,189 @@ class TestValidateErrors:
         )
         assert result.exit_code == 1
         assert not (tmp_path / "mcp-servers.jsonl").exists()
+
+
+class TestEject:
+    @staticmethod
+    def _managed(command, url, transport="streamablehttp"):
+        return {
+            "command": str(command),
+            "args": ["--transport", transport, url],
+        }
+
+    def test_eject_outputs_jsonl_and_clears_managed(self, config_env):
+        config_file, fake_proxy = config_env
+        notion_url = "https://mcp.notion.com/mcp"
+        linear_url = "https://mcp.linear.app/mcp"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": self._managed(fake_proxy, notion_url),
+                        "linear": self._managed(fake_proxy, linear_url),
+                        "hand-added": {
+                            "command": "/usr/bin/node",
+                            "args": ["server.js"],
+                        },
+                    }
+                }
+            )
+        )
+
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code == 0
+
+        # stdout: JSONL only, sorted alphabetically by name
+        stdout_lines = result.stdout.strip().splitlines()
+        assert len(stdout_lines) == 2
+        assert json.loads(stdout_lines[0]) == {"url": linear_url}
+        assert json.loads(stdout_lines[1]) == {"url": notion_url}
+
+        # stderr: status message
+        assert "Backup:" in result.stderr
+        assert "Wrote:" in result.stderr
+        assert "Ejected 2 entries" in result.stderr
+        assert "cdcasasagi revert" in result.stderr
+
+        # config: only hand-added remains
+        data = json.loads(config_file.read_text())
+        assert list(data["mcpServers"].keys()) == ["hand-added"]
+        assert config_file.with_suffix(".json.bak").exists()
+
+    def test_eject_omits_default_transport(self, config_env):
+        config_file, fake_proxy = config_env
+        url = "https://mcp.notion.com/mcp"
+        config_file.write_text(
+            json.dumps({"mcpServers": {"notion": self._managed(fake_proxy, url)}})
+        )
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code == 0
+        line = result.stdout.strip()
+        assert json.loads(line) == {"url": url}
+        assert "transport" not in line
+
+    def test_eject_emits_non_default_transport(self, config_env):
+        config_file, fake_proxy = config_env
+        url = "https://mcp.notion.com/mcp"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "notion": self._managed(fake_proxy, url, transport="sse"),
+                    }
+                }
+            )
+        )
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout.strip()) == {
+            "url": url,
+            "transport": "sse",
+        }
+
+    def test_eject_omits_derived_name(self, config_env):
+        config_file, fake_proxy = config_env
+        url = "https://mcp.notion.com/mcp"
+        # "notion" is the derived name from the hostname
+        config_file.write_text(
+            json.dumps({"mcpServers": {"notion": self._managed(fake_proxy, url)}})
+        )
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout.strip())
+        assert "name" not in payload
+
+    def test_eject_emits_custom_name(self, config_env):
+        config_file, fake_proxy = config_env
+        url = "https://mcp.notion.com/mcp"
+        config_file.write_text(
+            json.dumps({"mcpServers": {"my-notion": self._managed(fake_proxy, url)}})
+        )
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout.strip()) == {
+            "url": url,
+            "name": "my-notion",
+        }
+
+    def test_eject_no_op_when_no_managed(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "hand-added": {
+                            "command": "/usr/bin/node",
+                            "args": ["server.js"],
+                        }
+                    }
+                }
+            )
+        )
+        before = config_file.read_text()
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code == 0
+        assert result.stdout == ""
+        assert "No cdcasasagi-managed entries to eject." in result.stderr
+        assert config_file.read_text() == before
+        assert not config_file.with_suffix(".json.bak").exists()
+
+    def test_eject_no_op_when_config_missing(self, config_env):
+        config_file, _ = config_env
+        assert not config_file.exists()
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code == 0
+        assert result.stdout == ""
+        assert "No cdcasasagi-managed entries to eject." in result.stderr
+        assert not config_file.exists()
+        assert not config_file.with_suffix(".json.bak").exists()
+
+    def test_eject_then_import_roundtrips(self, config_env):
+        config_file, fake_proxy = config_env
+        notion_url = "https://mcp.notion.com/mcp"
+        linear_url = "https://mcp.linear.app/mcp"
+        original_servers = {
+            "linear": self._managed(fake_proxy, linear_url),
+            "my-notion": self._managed(fake_proxy, notion_url, transport="sse"),
+        }
+        config_file.write_text(json.dumps({"mcpServers": original_servers}))
+
+        eject_result = runner.invoke(app, ["eject"])
+        assert eject_result.exit_code == 0
+        jsonl = eject_result.stdout
+        assert json.loads(config_file.read_text())["mcpServers"] == {}
+
+        import_result = runner.invoke(app, ["import", "-", "--write"], input=jsonl)
+        assert import_result.exit_code == 0
+        restored = json.loads(config_file.read_text())["mcpServers"]
+        assert set(restored.keys()) == {"linear", "my-notion"}
+        assert restored["linear"]["args"][-1] == linear_url
+        assert restored["my-notion"]["args"][-1] == notion_url
+        assert restored["my-notion"]["args"][1] == "sse"
+
+    def test_eject_then_revert_restores(self, config_env):
+        config_file, fake_proxy = config_env
+        notion_url = "https://mcp.notion.com/mcp"
+        linear_url = "https://mcp.linear.app/mcp"
+        original = {
+            "mcpServers": {
+                "notion": self._managed(fake_proxy, notion_url),
+                "linear": self._managed(fake_proxy, linear_url),
+                "hand-added": {"command": "/usr/bin/node", "args": ["server.js"]},
+            }
+        }
+        config_file.write_text(json.dumps(original))
+
+        eject_result = runner.invoke(app, ["eject"])
+        assert eject_result.exit_code == 0
+
+        revert_result = runner.invoke(app, ["revert"])
+        assert revert_result.exit_code == 0
+        assert json.loads(config_file.read_text()) == original
+
+    def test_eject_corrupt_config(self, config_env):
+        config_file, _ = config_env
+        config_file.write_text("not json")
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code == 1
+        assert "Failed to parse JSON config file" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1746,6 +1746,29 @@ class TestEject:
             "name": "my-notion",
         }
 
+    def test_eject_jsonl_is_ascii_only(self, config_env):
+        # Server names can contain non-ASCII characters (e.g. via --name).
+        # The CLI must keep stdout ASCII so the JSONL is safe to print on
+        # Windows terminals using cp1252 (see AGENTS.md "CLI output must be
+        # ASCII-only"). The escaped form is still round-trippable through
+        # `import` because json.loads decodes \\uXXXX escapes.
+        config_file, fake_proxy = config_env
+        url = "https://mcp.notion.com/mcp"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "鵲": self._managed(fake_proxy, url),
+                    }
+                }
+            )
+        )
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code == 0
+        line = result.stdout.strip()
+        assert line.isascii(), f"stdout should be ASCII-only, got: {line!r}"
+        assert json.loads(line) == {"url": url, "name": "鵲"}
+
     def test_eject_no_op_when_no_managed(self, config_env):
         config_file, _ = config_env
         config_file.write_text(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1769,6 +1769,24 @@ class TestEject:
         assert line.isascii(), f"stdout should be ASCII-only, got: {line!r}"
         assert json.loads(line) == {"url": url, "name": "鵲"}
 
+    def test_eject_emits_no_jsonl_when_write_fails(self, config_env, monkeypatch):
+        # If write_config raises, stdout must stay empty so a scripted flow
+        # piping `eject` into `import` does not re-import against the still-
+        # present entries on a write failure.
+        config_file, fake_proxy = config_env
+        notion_url = "https://mcp.notion.com/mcp"
+        original = {"mcpServers": {"notion": self._managed(fake_proxy, notion_url)}}
+        config_file.write_text(json.dumps(original))
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("cdcasasagi.desktop_config.write_config", boom)
+        result = runner.invoke(app, ["eject"])
+        assert result.exit_code != 0
+        assert result.stdout == ""
+        assert json.loads(config_file.read_text()) == original
+
     def test_eject_no_op_when_no_managed(self, config_env):
         config_file, _ = config_env
         config_file.write_text(


### PR DESCRIPTION
## Summary

Adds `cdcasasagi eject` for the round-trip "I want to re-import a slightly modified version of what I just imported" workflow. Without it, the only path to a clean re-import is to remember the original JSONL or to wrestle with `--force` and conflict messages.

`eject`:

- prints all cdcasasagi-managed entries as import-format JSONL on **stdout**, with `transport`/`name` omitted when they match the defaults (`streamablehttp` / `derive_server_name(url)`) so the output stays minimal but round-trippable through `import`
- removes those entries from the config, leaving hand-added entries (whose `command` is not `mcp-proxy`) untouched
- writes a `.bak` via the existing `write_config`, so `cdcasasagi revert` undoes the eject
- prints the status summary on **stderr**, keeping stdout a clean JSONL stream that can be redirected to a file or piped straight back into `cdcasasagi import - --write`

Typical use:

```
cdcasasagi eject > backup.jsonl
# edit backup.jsonl
cdcasasagi import backup.jsonl --write
```

When there are no managed entries, `eject` is a no-op (no stdout, no config touch, no `.bak`) and just prints `No cdcasasagi-managed entries to eject.` on stderr.

README and `docs/author-workflow.md` are updated with the new command and the re-import workflow it enables.

## Test plan

- [x] `uv run --no-sync ruff format src/ tests/`
- [x] `uv run --no-sync ruff check src/ tests/`
- [x] `uv run --no-sync pytest` — 273 passed (10 new `TestEject` cases)
- [x] `cd e2e && CLAUDE_DESKTOP_CONFIG=/tmp/test-claude-config.json uv run gauge run specs` — 9 specs / 31 scenarios passed (4 new scenarios in `eject.spec`, including stdout-pipe-to-import round-trip and revert cleanup that mirrors `delete.spec`)
- [x] Manual round-trip: `add` two managed entries → `eject > dump.jsonl` → config cleared → `import dump.jsonl --write` restores the original config; `revert` also restores.

https://claude.ai/code/session_01JmYYyRL3yHmh6UJQdwy5Yp