### PR TITLE
ci(publish): Attach skill zip to GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,4 +34,5 @@ jobs:
     - name: Upload skill to release
       env:
         GH_TOKEN: ${{ github.token }}
-      run: gh release upload "${{ github.event.release.tag_name }}" cdcasasagi.zip --clobber
+        TAG: ${{ github.event.release.tag_name }}
+      run: gh release upload "$TAG" cdcasasagi.zip --clobber

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Package skill
       working-directory: skills
-      run: zip -r ../cdcasasagi.zip cdcasasagi
+      run: zip -ry ../cdcasasagi.zip cdcasasagi
     - name: Upload skill to release
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
 
   upload-skill:
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  deploy:
+  pypi-publish:
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -21,3 +21,17 @@ jobs:
       run: uv build
     - name: Publish
       uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+
+  upload-skill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Package skill
+      working-directory: skills
+      run: zip -r ../cdcasasagi.zip cdcasasagi
+    - name: Upload skill to release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release upload "${{ github.event.release.tag_name }}" cdcasasagi.zip --clobber


### PR DESCRIPTION
## Summary

- リリース公開時に `skills/cdcasasagi/` を ZIP 化し、GitHub Release のアセットとして `cdcasasagi.zip` を添付する。
- ZIP のルートは `cdcasasagi/`（Claude スキルのパッケージ仕様準拠：`cdcasasagi.zip/cdcasasagi/SKILL.md`）。
- 最小権限の原則に従い、`publish.yml` を 2 ジョブに分割：
  - `pypi-publish`: `contents:read` + `id-token:write`（既存の PyPI OIDC publish のみ）
  - `upload-skill`: `contents:write` のみ（リリースへの ZIP 添付のみ。PyPI トークン発行能力を持たない）

これにより、片方のジョブが侵害されても他方の能力（PyPI 公開 / リリース改ざん）は奪われない。

## Test plan

- [ ] ローカルで ZIP 構造を検証済み: `cd skills && zip -r /tmp/cdcasasagi.zip cdcasasagi && unzip -l /tmp/cdcasasagi.zip` で `cdcasasagi/` と `cdcasasagi/SKILL.md` のみ（`skills/` 接頭辞は含まれない）。
- [ ] 次回 `v0.7.1` 等のリリース公開時に Actions タブで `pypi-publish` と `upload-skill` の 2 ジョブが並列実行されることを確認。
- [ ] PyPI に新バージョンが公開されることを確認。
- [ ] リリースページに `cdcasasagi.zip` が添付されることを確認。
- [ ] ダウンロード後 `unzip cdcasasagi.zip` で `cdcasasagi/SKILL.md` が現れ、`cp -r cdcasasagi ~/.claude/skills/` でインストール可能なことを確認。

https://claude.ai/code/session_01HzVohDifsGaGrvcKutacTe

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzVohDifsGaGrvcKutacTe)_